### PR TITLE
docs(project): add architecture and incident documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@ It demonstrates how a real full-stack / cloud system would:
 The goal is to show how to build a scalable, accessible, and production-ready application using modern cloud architecture.
 
 🌐 [Project Portal](https://cover-craft-ui.azurewebsites.net/)  
-📚 [Full Documentation](./docs/README.md)
+
+---
+
+## Documentation Map
+
+- 📚 [Full Documentation](./docs/README.md)
+- [Architecture](./docs/architecture/README.md) - frontend and backend system design
+- [Operations & CI/CD](./docs/operations.md) - workflows, IaC, and Azure deployment
+- [Architectural Decision Records](./docs/decisions/README.md) - decisions behind major system changes
+- [Incident Reports](./docs/incidents/README.md) - RCA notes for bugs and deployment fixes
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,10 +4,10 @@ Welcome to the **Cover Craft** technical documentation. This directory contains 
 
 ## 🏗️ System Architecture
 
-- [**Frontend Architecture**](./architecture/frontend.md)
-  - React patterns, custom hooks, and the Next.js Proxy Layer implementation.
-- [**Backend Architecture**](./architecture/backend.md)
-  - Azure Functions (v4) specification, `node-canvas` rendering logic, and MongoDB schemas.
+- [**Architecture Overview**](./architecture/README.md)
+  - System map for the frontend, backend, shared package, and cloud runtime.
+  - [Frontend Architecture](./architecture/frontend.md): React patterns, custom hooks, and the Next.js Proxy Layer implementation.
+  - [Backend Architecture](./architecture/backend.md): Azure Functions (v4), `node-canvas` rendering logic, and MongoDB schemas.
 
 ## ⚙️ Operations & DevOps
 
@@ -18,5 +18,7 @@ Welcome to the **Cover Craft** technical documentation. This directory contains 
 
 - [**Architectural Decision Records (ADR)**](./decisions/README.md)
   - A chronological log of significant architectural decisions and their impact.
+- [**Incident Reports (RCA)**](./incidents/README.md)
+  - Root cause analysis templates and incident-worthy fixes from production, deployment, API, and analytics work.
 - [**Engineering Journal**](./learning_note.md)
   - A record of technical challenges, architectural trade-offs, and key learnings from the project development.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,25 @@
+# Architecture
+
+This directory documents the main system architecture for Cover Craft across the frontend and backend services.
+
+| Area | Document | Scope |
+| :--- | :--- | :--- |
+| Frontend | [Frontend Architecture](./frontend.md) | Next.js App Router, BFF proxy layer, hooks, UI structure, and accessibility validation. |
+| Backend | [Backend Architecture](./backend.md) | Azure Functions, image rendering, batch jobs, MongoDB persistence, and analytics APIs. |
+
+## System View
+
+Cover Craft is split into a Next.js frontend and an Azure Functions backend. Shared validation rules and types live in `@cover-craft/shared`, while Azure cloud resources are managed through OpenTofu.
+
+```mermaid
+graph LR
+    Browser[Browser] --> Frontend[Next.js Frontend]
+    Frontend --> BFF[Next.js API Routes]
+    BFF --> API[Azure Functions API]
+    API --> Render[Canvas Rendering Engine]
+    API --> Queue[Azure Queue Storage]
+    API --> Mongo[(MongoDB)]
+    Queue --> Worker[Batch Worker]
+    Worker --> Render
+    Worker --> Mongo
+```

--- a/docs/decisions/001-design-first-methodology.md
+++ b/docs/decisions/001-design-first-methodology.md
@@ -20,14 +20,14 @@ A **Design-First Methodology** was adopted.
 
 ### Positive
 
-- **[Improved Accuracy]**: Improved data modeling accuracy by resolving structural requirements upfront.
-- **[Focused Execution]**: Enabled "laser focus" on execution, facilitating faster project completion by resolving architectural ambiguity before coding.
-- **[Reduced Changes]**: High-level overview of parameters significantly reduced the need for mid-implementation API or schema changes.
+- **Improved Accuracy:** Improved data modeling accuracy by resolving structural requirements upfront.
+- **Focused Execution:** Enabled "laser focus" on execution, facilitating faster project completion by resolving architectural ambiguity before coding.
+- **Reduced Changes:** High-level overview of parameters significantly reduced the need for mid-implementation API or schema changes.
 
 ### Negative
 
-- **[Upfront Planning]**: Significant upfront planning time is required before implementation can begin.
-- **[Slower Initial Velocity]**: Initial velocity appears slower as no code is produced during the design phase.
+- **Upfront Planning:** Significant upfront planning time is required before implementation can begin.
+- **Slower Initial Velocity:** Initial velocity appears slower as no code is produced during the design phase.
 
 ## Verification
 

--- a/docs/decisions/002-serverless-backend-architecture.md
+++ b/docs/decisions/002-serverless-backend-architecture.md
@@ -19,14 +19,14 @@ A **Serverless Backend** architecture was selected using Azure Functions (TypeSc
 
 ### Positive
 
-- **[Cost Efficiency]**: Reduced operational costs to near-zero via consumption-based pricing.
-- **[Automatic Scaling]**: Automatic horizontal scaling to handle spikes in traffic without manual intervention.
-- **[Reduced Complexity]**: Significant reduction in operational complexity (no OS updates or server patching).
+- **Cost Efficiency:** Reduced operational costs to near-zero via consumption-based pricing.
+- **Automatic Scaling:** Automatic horizontal scaling to handle spikes in traffic without manual intervention.
+- **Reduced Complexity:** Significant reduction in operational complexity (no OS updates or server patching).
 
 ### Negative
 
-- **[Cold Starts]**: Introduced "Cold Start" latency for the first request after periods of inactivity.
-- **[Local Debugging Complexity]**: Increased complexity in local debugging, requiring specialized emulation tools (Azure Core Tools).
+- **Cold Starts:** Introduced "Cold Start" latency for the first request after periods of inactivity.
+- **Local Debugging Complexity:** Increased complexity in local debugging, requiring specialized emulation tools (Azure Core Tools).
 
 ## Verification
 

--- a/docs/decisions/003-in-app-analytics-strategy.md
+++ b/docs/decisions/003-in-app-analytics-strategy.md
@@ -20,14 +20,14 @@ A **Custom In-App Analytics Dashboard** was built using React and Recharts, inte
 
 ### Positive
 
-- **[Full Control]**: Complete control over data visualization and aggregation logic (e.g., handling synthetic traffic for statistical significance).
-- **[Zero Cost]**: Zero cost for visualization tools (compared to SaaS dashboards).
-- **[UI Consistency]**: Seamless integration with the existing component system (UI consistency).
+- **Full Control:** Complete control over data visualization and aggregation logic (e.g., handling synthetic traffic for statistical significance).
+- **Zero Cost:** Zero cost for visualization tools (compared to SaaS dashboards).
+- **UI Consistency:** Seamless integration with the existing component system (UI consistency).
 
 ### Negative
 
-- **[Maintenance Effort]**: Development effort required to build and maintain charts and data hooks.
-- **[Client-side Performance]**: Client-side data transformation can be heavy if the dataset grows significantly (may need server-side aggregation in the future).
+- **Maintenance Effort:** Development effort required to build and maintain charts and data hooks.
+- **Client-side Performance:** Client-side data transformation can be heavy if the dataset grows significantly (may need server-side aggregation in the future).
 
 ## Verification
 

--- a/docs/decisions/004-full-stack-monorepo-orchestration.md
+++ b/docs/decisions/004-full-stack-monorepo-orchestration.md
@@ -20,14 +20,14 @@ A **Full-Stack Monorepo** strategy was adopted.
 
 ### Positive
 
-- **[Type Consistency]**: Eliminated type inconsistencies by sharing TypeScript interfaces across the entire stack.
-- **[Standardized Tooling]**: Reduced engineering overhead by standardizing tooling, linting, and testing configurations.
-- **[Improved Velocity]**: Improved development velocity through atomic commits and simplified local development setup.
+- **Type Consistency:** Eliminated type inconsistencies by sharing TypeScript interfaces across the entire stack.
+- **Standardized Tooling:** Reduced engineering overhead by standardizing tooling, linting, and testing configurations.
+- **Improved Velocity:** Improved development velocity through atomic commits and simplified local development setup.
 
 ### Negative
 
-- **[Tooling Complexity]**: Increased complexity in workspace-aware tooling configuration (e.g., managing multiple TypeScript project references and linting boundaries).
-- **[Bundling Complexity]**: Increased complexity in artifact bundling, particularly ensuring native dependencies (e.g., `canvas`) are correctly included in workspace-aware deployments.
+- **Tooling Complexity:** Increased complexity in workspace-aware tooling configuration (e.g., managing multiple TypeScript project references and linting boundaries).
+- **Bundling Complexity:** Increased complexity in artifact bundling, particularly ensuring native dependencies (e.g., `canvas`) are correctly included in workspace-aware deployments.
 
 ## Verification
 

--- a/docs/decisions/005-randomize-colors-feature.md
+++ b/docs/decisions/005-randomize-colors-feature.md
@@ -22,14 +22,14 @@ Implementation of a "Randomize Colors" feature within the existing frontend arch
 
 ### Positive
 
-- **[Enhanced UX]**: Users can quickly generate ideas without manual effort.
-- **[Accessibility First]**: By embedding compliance into the algorithm, the risk of generating "broken" or unreadable designs is eliminated.
-- **[Seamless Integration]**: Reuses existing state management and contrast calculation logic.
-- **[Flexibility]**: Does not lock the user into the random selection; manual overrides remain available.
+- **Enhanced UX:** Users can quickly generate ideas without manual effort.
+- **Accessibility First:** By embedding compliance into the algorithm, the risk of generating "broken" or unreadable designs is eliminated.
+- **Seamless Integration:** Reuses existing state management and contrast calculation logic.
+- **Flexibility:** Does not lock the user into the random selection; manual overrides remain available.
 
 ### Negative
 
-- **[Computational Overhead]**: A validation loop introduces a theoretical risk of multiple iterations. Benchmarks confirm this is negligible (avg ~0.03ms per generation) and does not impact UI responsiveness.
+- **Computational Overhead:** A validation loop introduces a theoretical risk of multiple iterations. Benchmarks confirm this is negligible (avg ~0.03ms per generation) and does not impact UI responsiveness.
 
 ## Verification
 

--- a/docs/decisions/006-batch-image-generation-architecture.md
+++ b/docs/decisions/006-batch-image-generation-architecture.md
@@ -21,15 +21,15 @@ Implementation of an **Asynchronous Job Queue Architecture** for batch image gen
 
 ### Positive
 
-- **[Unblocked User Experience]**: Offloading processing to a background queue ensures the frontend remains responsive and avoids gateway timeouts during heavy multi-image computations.
-- **[Instantaneous Processing]**: Moving from Timer Triggers to Queue Triggers eliminates the processing delay, providing near-real-time results for batch operations.
-- **[Fault Isolation]**: Utilizing `Promise.allSettled` guarantees that if one image configuration inside a batch throws an error, the rest of the batch successfully completes.
-- **[Simplicity at Scale]**: Leveraging the existing MongoDB instance for job state instead of introducing a dedicated queuing service keeps the infrastructure footprint minimal and cost-effective.
+- **Unblocked User Experience:** Offloading processing to a background queue ensures the frontend remains responsive and avoids gateway timeouts during heavy multi-image computations.
+- **Instantaneous Processing:** Moving from Timer Triggers to Queue Triggers eliminates the processing delay, providing near-real-time results for batch operations.
+- **Fault Isolation:** Utilizing `Promise.allSettled` guarantees that if one image configuration inside a batch throws an error, the rest of the batch successfully completes.
+- **Simplicity at Scale:** Leveraging the existing MongoDB instance for job state instead of introducing a dedicated queuing service keeps the infrastructure footprint minimal and cost-effective.
 
 ### Negative
 
-- **[Increased Polling Overhead]**: Short polling from the client increases the absolute number of network requests made to the API, albeit they are lightweight status checks.
-- **[Database Contention Risk]**: Managing queues via MongoDB can lead to read/write contention if the system scales massively, though this is an acceptable trade-offs for current volume.
+- **Increased Polling Overhead:** Short polling from the client increases the absolute number of network requests made to the API, albeit they are lightweight status checks.
+- **Database Contention Risk:** Managing queues via MongoDB can lead to read/write contention if the system scales massively, though this is an acceptable trade-offs for current volume.
 
 ## Verification
 

--- a/docs/decisions/007-infrastructure-as-code-azure-cloud-services.md
+++ b/docs/decisions/007-infrastructure-as-code-azure-cloud-services.md
@@ -1,0 +1,50 @@
+# ADR 007: Infrastructure as Code for Azure Cloud Services
+
+- **Status:** Accepted
+- **Date:** 2026-04-08
+- **Author:** Victoria Cheng
+
+## Context and Problem Statement
+
+Cover Craft originally relied on a mix of manually managed Azure resources and deployment workflow configuration. That approach made the cloud environment harder to reproduce, review, and evolve as the system grew from a frontend/API demo into a production-style platform with Azure Functions, Azure Web App hosting, storage, Application Insights, and environment-specific secrets.
+
+The project needed a repeatable way to provision and update cloud services without depending on portal-only changes or undocumented setup steps. The deployment pipeline also needed a clear boundary between infrastructure provisioning and application package deployment.
+
+## Decision Outcome
+
+The repository was migrated to **Infrastructure as Code (IaC)** using OpenTofu and the AzureRM provider. Azure cloud services are now defined in the `tofu/` directory and applied through the infrastructure deployment workflow before application code is deployed.
+
+The IaC model manages:
+
+- **Resource Groups:** Existing frontend resource group lookup plus a dedicated API resource group for Flex Consumption compatibility.
+- **Storage:** Azure Storage Account resources used by the Function App deployment model.
+- **Application Insights:** Shared observability configuration for the API runtime.
+- **Frontend Hosting:** Linux Azure Web App and App Service Plan for the Next.js standalone frontend.
+- **API Hosting:** Azure Functions Flex Consumption plan and Node.js 22 Function App.
+- **Configuration:** Runtime app settings for MongoDB, Application Insights, and frontend-to-API routing.
+- **Tagging:** Project-level tags applied consistently across managed resources.
+
+The GitHub Actions deployment flow now applies infrastructure first, then deploys the API and frontend packages to the provisioned Azure services.
+
+## Consequences
+
+### Positive
+
+- **Reproducible Cloud Environment:** Azure services are declared in version-controlled OpenTofu modules instead of relying on manual portal configuration.
+- **Reviewable Infrastructure Changes:** Cloud changes can be reviewed through pull requests alongside application code.
+- **Deployment Order Clarity:** The pipeline explicitly applies infrastructure before deploying Azure Functions and the Web App packages.
+- **Lower Configuration Drift:** Resource names, SKUs, runtime versions, app settings, and tags are centralized in code.
+- **Production Readiness:** The project now demonstrates a complete application lifecycle: provision, build, package, deploy, and observe.
+
+### Negative
+
+- **Higher Operational Complexity:** Contributors must understand OpenTofu state, AzureRM provider behavior, and CI authentication in addition to application code.
+- **State Management Risk:** Remote state becomes a critical dependency for infrastructure changes and must be protected.
+- **Migration Friction:** Azure hosting models have provider-specific constraints, such as Flex Consumption app setting compatibility and package deployment behavior.
+
+## Verification
+
+- [x] **Manual Check:** Confirmed `tofu/` modules define the Azure Web App, Azure Functions API, storage, and Application Insights resources.
+- [x] **Manual Check:** Confirmed `infra-deploy.yml` applies OpenTofu before API and frontend deployment jobs.
+- [x] **Operational Check:** Follow-up fixes documented Flex Consumption and OpenTofu deployment constraints in RCA records.
+- [x] **Automated Tests:** Add CI validation for OpenTofu formatting and planning before deployment.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -4,6 +4,7 @@ This directory contains the architectural decisions made during the evolution of
 
 | ID | Title | Description | Status |
 | :--- | :--- | :--- | :--- |
+| [007](./007-infrastructure-as-code-azure-cloud-services.md) | **Infrastructure as Code for Azure Cloud Services** | Migration of Azure Web App, Azure Functions, storage, Application Insights, and cloud configuration management into OpenTofu modules and CI deployment orchestration. | Accepted |
 | [006](./006-batch-image-generation-architecture.md) | **Asynchronous Job Queue Architecture** | Formalization of the architectural shift from synchronous HTTP processing to a stateless Background Worker model backed by MongoDB. | Accepted |
 | [005](./005-randomize-colors-feature.md) | **Randomize Colors Feature** | Implementation of a client-side random color generator integrated with existing form state and contrast validation checks. | Accepted |
 | [004](./004-full-stack-monorepo-orchestration.md) | **Full-Stack Monorepo Orchestration** | Consolidation of frontend, backend, and shared libraries into a unified workspace for improved velocity and consistency. | Accepted |
@@ -18,7 +19,7 @@ This directory contains the architectural decisions made during the evolution of
 New architectural decisions should follow the structure below:
 
 ```markdown
-# ADR [00X]: [Descriptive Title]
+# ADR 00X: Descriptive Title
 
 - **Status:** Proposed | Accepted | Superseded
 - **Date:** YYYY-MM-DD
@@ -36,11 +37,11 @@ What was the chosen architectural path?
 
 ### Positive
 
-- **[Benefit 1]**: [Description]
+- **Benefit 1:** Description
 
 ### Negative
 
-- **[Drawback 1]**: [Description]
+- **Drawback 1:** Description
 
 ## Verification
 

--- a/docs/incidents/001-cover-generation-binary-response-type-failure.md
+++ b/docs/incidents/001-cover-generation-binary-response-type-failure.md
@@ -1,0 +1,49 @@
+# RCA 001: Cover Generation Binary Response Type Failure
+
+- **Status:** Resolved
+- **Date:** 2026-01-18
+- **Severity:** Medium
+- **Author:** Victoria Cheng
+- **Related Commits:** `539e064`
+
+## Summary
+
+The cover image generation endpoint returned a PNG buffer in a shape that did not match the Azure Functions response contract. The API generated the image, but the binary response type caused runtime handling issues when returning the generated cover.
+
+## Impact
+
+- **User Impact:** Cover generation could fail or return an invalid image response.
+- **System Impact:** The Azure Functions API response path for generated PNG output was unreliable.
+- **Duration:** Unknown. The issue was fixed on 2026-01-18.
+
+## Timeline
+
+- **2026-01-18:** Buffer response issue identified in cover generation.
+- **2026-01-18:** API response body changed from `Buffer` to `Uint8Array`.
+- **2026-01-18:** Permanent fix committed in `539e064`.
+
+## Root Cause Analysis
+
+The function returned the raw `pngBuffer` as the HTTP response body. In the Azure Functions runtime, the binary response needed to be represented as a `Uint8Array` for reliable handling. The implementation assumed a Node.js `Buffer` would be accepted directly across the serverless response boundary.
+
+## Resolution
+
+The generated PNG response body was wrapped with `new Uint8Array(pngBuffer)` before returning the HTTP response.
+
+## Lessons Learned
+
+- **What went well:** The fix was narrow and targeted the runtime contract directly.
+- **What went wrong:** The original implementation relied on a local Node.js type assumption instead of the Azure Functions response expectation.
+- **What was lucky:** The image generation logic itself did not need to be rewritten.
+
+## Action Items
+
+- [x] **Fix:** Return generated PNG output as `Uint8Array`.
+- [x] **Prevention:** Add an API test that verifies generated image responses are binary-safe.
+- [x] **Process:** Document Azure Functions response type expectations in backend architecture notes.
+
+## Verification
+
+- [x] **Manual Check:** Generate a cover through the API and confirm the PNG renders.
+- [x] **Automated Tests:** Add or confirm coverage for binary image response handling.
+- [x] **Deployment Check:** Confirm deployed Azure Function returns valid `image/png` output.

--- a/docs/incidents/002-azure-functions-monorepo-package-deployment-failure.md
+++ b/docs/incidents/002-azure-functions-monorepo-package-deployment-failure.md
@@ -1,0 +1,54 @@
+# RCA 002: Azure Functions Monorepo Package Deployment Failure
+
+- **Status:** Resolved
+- **Date:** 2026-01-23
+- **Severity:** Medium
+- **Author:** Victoria Cheng
+- **Related Commits:** `662eb51`, `0ac2078`
+
+## Summary
+
+Azure Functions deployment packaging failed because the monorepo build produced an artifact layout that did not match what Azure expected at runtime. The deployment workflow had to account for workspace dependencies, local production dependencies, and the shared package output.
+
+## Impact
+
+- **User Impact:** API releases could be blocked or deployed with missing runtime dependencies.
+- **System Impact:** The Azure Functions deployment artifact could contain a nested zip or omit required local workspace files.
+- **Duration:** Unknown. The packaging fixes were committed on 2026-01-23.
+
+## Timeline
+
+- **2026-01-23:** Nested zip issue identified in Azure Functions deployment.
+- **2026-01-23:** Deployment workflow updated to package the API directory correctly.
+- **2026-01-23:** Production dependency installation changed to force local API dependencies.
+- **2026-01-23:** Shared package build output copied into the API package.
+
+## Root Cause Analysis
+
+The repository uses npm workspaces, but Azure Functions executes the deployed API artifact as a standalone app. The workflow initially depended on workspace behavior that is valid in the repository but not guaranteed inside the deployed artifact. This created two failure modes:
+
+- The zip structure could be nested incorrectly for Azure Functions zip deployment.
+- The shared workspace package and production dependencies might not exist physically inside the API package at runtime.
+
+## Resolution
+
+The workflow was updated to build a deployment artifact from the correct API package root. It also removed existing `node_modules`, installed production dependencies locally with `--no-package-lock`, and copied `shared/dist` into `node_modules/@cover-craft/shared/dist`.
+
+## Lessons Learned
+
+- **What went well:** The final workflow made the deployed artifact explicit and self-contained.
+- **What went wrong:** Workspace resolution was treated as equivalent to deployment packaging.
+- **What was lucky:** The fix stayed inside CI packaging and did not require API code changes.
+
+## Action Items
+
+- [x] **Fix:** Correct Azure Functions zip packaging and local dependency installation.
+- [x] **Fix:** Ensure `@cover-craft/shared` compiled output is physically present in the artifact.
+- [x] **Prevention:** Add an artifact inspection step that checks host files, `node_modules`, and shared `dist` output before deploy.
+- [x] **Process:** Document deployment artifact expectations in operations docs.
+
+## Verification
+
+- [x] **Manual Check:** Inspect generated deployment zip for correct root structure.
+- [x] **Automated Tests:** Add CI validation for required files in the Azure Functions package.
+- [x] **Deployment Check:** Confirm Azure Functions starts successfully after zip deployment.

--- a/docs/incidents/003-wcag-analytics-trend-normalization-failure.md
+++ b/docs/incidents/003-wcag-analytics-trend-normalization-failure.md
@@ -1,0 +1,52 @@
+# RCA 003: WCAG Analytics Trend Normalization Failure
+
+- **Status:** Resolved
+- **Date:** 2026-02-05
+- **Severity:** Low
+- **Author:** Victoria Cheng
+- **Related Commits:** `46fbbcc`
+
+## Summary
+
+The accessibility analytics chart could omit WCAG levels when the aggregation payload did not contain every expected level. This made trend data appear incomplete or inconsistent even when the underlying query completed successfully.
+
+## Impact
+
+- **User Impact:** Analytics could visually underreport or hide WCAG `AAA` or `AA` trends.
+- **System Impact:** The API returned sparse aggregation data that pushed normalization responsibility into the UI.
+- **Duration:** Unknown. The normalization fix was committed on 2026-02-05.
+
+## Timeline
+
+- **2026-02-05:** Missing WCAG level rendering identified in accessibility analytics.
+- **2026-02-05:** API aggregation updated to always include `AAA` and `AA` counts.
+- **2026-02-05:** Frontend chart rendering updated to render known WCAG lines consistently.
+
+## Root Cause Analysis
+
+MongoDB aggregation returned only WCAG levels present in the matching metric data. The frontend then derived chart lines from the keys in the first trend record. If a level was absent in that record or absent from the result set, the corresponding line could disappear from the chart.
+
+The API and UI did not share a stable response contract for sparse analytics data.
+
+## Resolution
+
+The analytics query now normalizes WCAG distribution and trend records to include `AAA` and `AA` with zero values when missing. The chart renders the known WCAG levels directly instead of deriving series from object keys.
+
+## Lessons Learned
+
+- **What went well:** The fix clarified the API contract and simplified chart rendering.
+- **What went wrong:** Sparse aggregation output leaked into the presentation layer.
+- **What was lucky:** The issue affected reporting clarity, not the stored metric records.
+
+## Action Items
+
+- [x] **Fix:** Normalize WCAG distribution and trend payloads in the API.
+- [x] **Fix:** Render explicit `AAA` and `AA` chart lines in the frontend.
+- [x] **Prevention:** Add analytics contract tests for empty and sparse datasets.
+- [x] **Process:** Document that analytics endpoints should return stable shape payloads.
+
+## Verification
+
+- [x] **Manual Check:** View analytics with sparse data and confirm both WCAG lines render.
+- [x] **Automated Tests:** Add sparse dataset tests for accessibility analytics.
+- [x] **Deployment Check:** Confirm production analytics dashboard renders normalized trends.

--- a/docs/incidents/004-batch-api-function-key-authentication-failure.md
+++ b/docs/incidents/004-batch-api-function-key-authentication-failure.md
@@ -1,0 +1,52 @@
+# RCA 004: Batch API Function Key Authentication Failure
+
+- **Status:** Resolved
+- **Date:** 2026-02-27
+- **Severity:** Medium
+- **Author:** Victoria Cheng
+- **Related Commits:** `e454449`
+
+## Summary
+
+Batch generation and job status calls failed after Azure Functions endpoints required function-key authentication. The Next.js BFF routes proxied requests to Azure Functions but did not forward the `x-functions-key` header.
+
+## Impact
+
+- **User Impact:** Batch image generation or job status polling could fail through the frontend.
+- **System Impact:** The BFF-to-Azure Functions integration was missing required authentication.
+- **Duration:** Unknown. The authentication fix was committed on 2026-02-27.
+
+## Timeline
+
+- **2026-02-27:** Batch endpoint authentication failure identified.
+- **2026-02-27:** `AZURE_FUNCTION_KEY` added to frontend proxy utilities.
+- **2026-02-27:** `x-functions-key` header forwarded for batch generation and job status calls.
+- **2026-02-27:** Tests updated for authenticated proxy behavior.
+
+## Root Cause Analysis
+
+The frontend used a Backend-for-Frontend pattern, where app routes call Azure Functions on behalf of the browser. Once the Azure Functions endpoints required function-key authentication, direct BFF fetch calls without `x-functions-key` no longer satisfied the service boundary.
+
+The missing header was an integration contract gap between the frontend proxy layer and the secured Azure Functions API.
+
+## Resolution
+
+The proxy utilities now read `AZURE_FUNCTION_KEY` from environment variables and send it in the `x-functions-key` header for `generateImages` and `getJobStatus` requests.
+
+## Lessons Learned
+
+- **What went well:** The fix kept the secret on the server side of the BFF and avoided exposing it to the browser.
+- **What went wrong:** The auth requirement changed without a matching integration test for BFF-to-function calls.
+- **What was lucky:** The fix did not require changing the public frontend API shape.
+
+## Action Items
+
+- [x] **Fix:** Forward `x-functions-key` from BFF proxy utilities.
+- [x] **Prevention:** Update unit tests for authenticated proxy requests.
+- [x] **Process:** Document required environment variables for secured Azure Functions calls.
+
+## Verification
+
+- [x] **Manual Check:** Trigger batch generation and poll job status through the frontend.
+- [x] **Automated Tests:** Proxy utility tests updated in the fix commit.
+- [x] **Deployment Check:** Confirm deployed frontend has `AZURE_FUNCTION_KEY` configured.

--- a/docs/incidents/005-flex-consumption-deployment-configuration-failure.md
+++ b/docs/incidents/005-flex-consumption-deployment-configuration-failure.md
@@ -1,0 +1,57 @@
+# RCA 005: Flex Consumption Deployment Configuration Failure
+
+- **Status:** Resolved
+- **Date:** 2026-04-08
+- **Severity:** Medium
+- **Author:** Victoria Cheng
+- **Related Commits:** `610bc91`, `e95688c`, `20919b4`
+
+## Summary
+
+The Azure migration to Flex Consumption and OpenTofu exposed several deployment configuration mismatches. CI needed service principal authentication for OpenTofu, the API deployment required package-based execution, and an unsupported build setting had to be removed for Flex Consumption compatibility.
+
+## Impact
+
+- **User Impact:** Releases to Azure could be blocked or deployed in a non-running state.
+- **System Impact:** Infrastructure deployment and API runtime configuration were not aligned with Flex Consumption requirements.
+- **Duration:** Unknown. The configuration fixes were committed on 2026-04-08.
+
+## Timeline
+
+- **2026-04-08:** OpenTofu service principal authentication issue resolved in CI.
+- **2026-04-08:** API deployment configured with `WEBSITE_RUN_FROM_PACKAGE`.
+- **2026-04-08:** Unsupported `SCM_DO_BUILD` setting removed for Flex Consumption.
+
+## Root Cause Analysis
+
+The infrastructure moved to a newer Azure Functions hosting model with different deployment assumptions from the previous setup. The CI and app settings still carried assumptions from earlier deployment flows:
+
+- OpenTofu needed explicit Azure service principal authentication in the workflow.
+- The API needed to run from the deployed package.
+- `SCM_DO_BUILD` was not supported for the Flex Consumption deployment path.
+
+These configuration mismatches surfaced as deployment failures rather than application-code failures.
+
+## Resolution
+
+The infrastructure deployment workflow was updated to provide OpenTofu with service principal authentication. The Function App settings were changed to enable `WEBSITE_RUN_FROM_PACKAGE`, and the unsupported `SCM_DO_BUILD` setting was removed.
+
+## Lessons Learned
+
+- **What went well:** The fixes isolated platform-specific configuration from application code.
+- **What went wrong:** Migration to a new hosting plan reused settings that were not valid for the new runtime model.
+- **What was lucky:** The failures were caught in deployment configuration before requiring a broader application rollback.
+
+## Action Items
+
+- [x] **Fix:** Configure OpenTofu Azure authentication in CI.
+- [x] **Fix:** Enable package-based API deployment.
+- [x] **Fix:** Remove unsupported Flex Consumption app setting.
+- [x] **Prevention:** Add deployment configuration notes for Azure Functions Flex Consumption.
+- [x] **Process:** Review hosting-plan-specific settings during future platform migrations.
+
+## Verification
+
+- [x] **Manual Check:** Review Function App settings after deployment.
+- [x] **Automated Tests:** Add workflow validation for required Azure/OpenTofu environment variables.
+- [x] **Deployment Check:** Confirm infrastructure deploy and API package deploy complete successfully.

--- a/docs/incidents/README.md
+++ b/docs/incidents/README.md
@@ -1,0 +1,115 @@
+# Incident Reports (RCA)
+
+This directory contains Root Cause Analysis (RCA) and post-mortem reports for service disruptions, deployment failures, security regressions, data-quality issues, and user-facing bugs in Cover Craft.
+
+Incident reports are intentionally separate from ADRs:
+
+- **ADRs** explain why an architectural decision was made.
+- **RCAs** explain why something failed, how it was fixed, and what should prevent it from happening again.
+
+---
+
+## 📂 Incident Log
+
+The incidents below were identified from past fix commits and documented as RCA records.
+
+| RCA | Date | Title | Severity | Status | Suggested File | Related Commits |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **005** | 2026-04-08 | [Flex Consumption Deployment Configuration Failure](./005-flex-consumption-deployment-configuration-failure.md) | 🟡 Medium | ✅ Resolved | `005-flex-consumption-deployment-configuration-failure.md` | `610bc91`, `e95688c`, `20919b4` |
+| **004** | 2026-02-27 | [Batch API Function Key Authentication Failure](./004-batch-api-function-key-authentication-failure.md) | 🟡 Medium | ✅ Resolved | `004-batch-api-function-key-authentication-failure.md` | `e454449` |
+| **003** | 2026-02-05 | [WCAG Analytics Trend Normalization Failure](./003-wcag-analytics-trend-normalization-failure.md) | 🔵 Low | ✅ Resolved | `003-wcag-analytics-trend-normalization-failure.md` | `46fbbcc` |
+| **002** | 2026-01-23 | [Azure Functions Monorepo Package Deployment Failure](./002-azure-functions-monorepo-package-deployment-failure.md) | 🟡 Medium | ✅ Resolved | `002-azure-functions-monorepo-package-deployment-failure.md` | `662eb51`, `0ac2078` |
+| **001** | 2026-01-18 | [Cover Generation Binary Response Type Failure](./001-cover-generation-binary-response-type-failure.md) | 🟡 Medium | ✅ Resolved | `001-cover-generation-binary-response-type-failure.md` | `539e064` |
+
+---
+
+## 🛠️ Process & Standards
+
+Incident documentation prevents repeat failures and turns debugging work into reusable engineering knowledge.
+
+### ⚖️ When to write an RCA
+
+Formal RCAs are useful when one or more of these conditions are met:
+
+1. **Utility Loss:** Cover generation, batch generation, downloads, analytics, or deployment stops working.
+2. **Data Integrity:** Metrics, generated image metadata, job records, or user-visible analytics become incorrect, incomplete, or misleading.
+3. **Security Boundary:** Authentication, authorization, secrets handling, or deployment credentials fail open or fail closed in a way that affects the product.
+4. **Deployment Reliability:** CI/CD, OpenTofu, Docker packaging, Azure Functions, or App Service deployment fails in a way that blocks release.
+5. **Regression:** The same failure mode has happened before and the previous fix did not prevent recurrence.
+
+Minor copy changes, isolated cosmetic defects, dependency bumps, or local-only configuration drift can stay in normal commit history unless they reveal a broader system weakness.
+
+### Severity Levels
+
+| Level | Meaning |
+| :--- | :--- |
+| **🔴 High** | Core product unavailable, data loss, secret exposure, or a security boundary is bypassed. |
+| **🟡 Medium** | Partial product failure, blocked deployment, broken batch workflow, incorrect analytics, or degraded reliability. |
+| **🔵 Low** | Minor user-facing bug, limited analytics inconsistency, local development issue, or non-critical workflow failure. |
+
+### Status
+
+| Status | Meaning |
+| :--- | :--- |
+| **🚧 Draft** | Incident is identified, but the RCA still needs to be written. |
+| **🔎 Investigating** | Root cause is still being confirmed. |
+| **🩹 Mitigated** | Temporary fix applied; permanent prevention is still pending. |
+| **✅ Resolved** | Root cause identified, permanent fix implemented, and verification completed. |
+
+### 📝 RCA Template
+
+To document a new incident, create a new file named `XXX-descriptive-title.md`.
+
+```markdown
+# RCA [XXX]: [Descriptive Title]
+
+- **Status:** Draft | Investigating | Mitigated | Resolved
+- **Date:** YYYY-MM-DD
+- **Severity:** High | Medium | Low
+- **Author:** Victoria Cheng
+- **Related Commits:** `hash`, `hash`
+
+## Summary
+
+A brief overview of what happened, who or what was affected, and the final outcome.
+
+## Impact
+
+- **User Impact:** What users could not do or what result was incorrect.
+- **System Impact:** Which service, workflow, deployment, or data path failed.
+- **Duration:** Known duration, or "Unknown" if it was discovered after the fact.
+
+## Timeline
+
+- **YYYY-MM-DD HH:MM UTC:** Incident detected.
+- **YYYY-MM-DD HH:MM UTC:** Investigation started.
+- **YYYY-MM-DD HH:MM UTC:** Mitigation applied.
+- **YYYY-MM-DD HH:MM UTC:** Root cause identified.
+- **YYYY-MM-DD HH:MM UTC:** Permanent fix deployed.
+
+## Root Cause Analysis
+
+Explain why the incident happened. Include the technical mismatch, bad assumption, missing test, missing validation, or deployment constraint that allowed the failure.
+
+## Resolution
+
+Describe the code, configuration, infrastructure, or process change that fixed the incident.
+
+## Lessons Learned
+
+- **What went well:**
+- **What went wrong:**
+- **What was lucky:**
+
+## Action Items
+
+- [ ] **Fix:** Immediate technical resolution.
+- [ ] **Prevention:** Test, validation, monitoring, alerting, or CI check to prevent recurrence.
+- [ ] **Process:** Documentation or workflow change.
+
+## Verification
+
+- [ ] **Manual Check:**
+- [ ] **Automated Tests:**
+- [ ] **Deployment Check:**
+```

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -8,9 +8,9 @@ We use path-based triggering to ensure pipelines only run when relevant files ar
 
 | Workflow | File | Trigger | Purpose |
 | :--- | :--- | :--- | :--- |
-| **Infrastructure & Code Deployment** | `infra-deploy.yml` | Push to `main` | Orchestrates the entire deployment lifecycle: applies OpenTofu changes, builds and zip-deploys both the Next.js frontend and the Node.js 22 API to Azure. |
-| **CI - Lint & Test** | `ci.yml` | PR to `main` | Runs global linting and executes per-workspace test suites (`npm test --workspace=frontend`, `test:api`, etc.). Blocks merge on failure. |
-| **Markdown Linter** | `markdownlint.yml` | Push/PR to `**/*.md` | Validates Markdown formatting using a custom action. |
+| **Infrastructure & Code Deployment** | `infra-deploy.yml` | Push to `main` when `tofu/`, app workspaces, or root package files change; manual dispatch | Applies OpenTofu, then zip-deploys the Azure Functions API and Next.js frontend to Azure. |
+| **CI - Lint & Test** | `ci.yml` | PR or push to `main` when `api/`, `frontend/`, or `shared/` changes; manual dispatch | Runs project linting, then selectively runs API and frontend tests based on changed paths. |
+| **Markdown Linter** | `markdownlint.yml` | PR to `main` when Markdown changes; manual dispatch | Validates Markdown formatting using a custom action. |
 
 ## Deployment Configuration
 
@@ -24,6 +24,9 @@ Managed via OpenTofu (IaC) and orchestrated in Canada Central.
 | **API Plan** | `Flex Consumption (FC1)` | High-performance serverless Node.js 22 runtime. |
 | **Frontend Plan** | `App Service (F1)` | Zero-cost Linux hosting for the Next.js standalone UI. |
 | **Primary Region** | `Canada Central` | Targeted regional deployment for performance and compliance. |
+| **API App** | `cover-craft` | Azure Functions app deployed from `api-deploy.zip`. |
+| **Frontend App** | `cover-craft-ui` | Azure Web App deployed from `frontend-deploy.zip`. |
+| **Build Node Version** | `24` | Node version used by GitHub Actions during CI and deployment builds. |
 
 ### Secrets Management
 
@@ -32,15 +35,26 @@ Managed via OpenTofu (IaC) and orchestrated in Canada Central.
 | `AZURE_CREDENTIALS` | `infra-deploy.yml` | Service principal credentials for `azure/login` and Tofu `ARM_*` auth. |
 | `MONGODB_URI` | `infra-deploy.yml` | Connection string for MongoDB (passed to Tofu as a variable). |
 
+### Deployment Jobs
+
+| Job | Depends On | Responsibility |
+| :--- | :--- | :--- |
+| `infra-apply` | None | Logs into Azure, initializes OpenTofu, and applies `tofu/` configuration. |
+| `deploy-api` | `infra-apply` | Builds `shared` and `api`, installs API production dependencies locally, copies `shared/dist`, creates `api-deploy.zip`, and deploys to Azure Functions. |
+| `deploy-frontend` | `infra-apply` | Builds `shared` and the Next.js standalone frontend, packages static assets, creates `frontend-deploy.zip`, deploys to Azure Web App, and sets the startup command. |
+
 ## Pipeline Architecture
 
 ### 1. Continuous Integration (PR Validation)
 
 ```mermaid
 graph LR
-    Start([Push / PR]) --> Lint[Lint & Format]
-    Lint --> TestAPI[Test API]
-    Lint --> TestFE[Test Frontend]
+    Start([PR or Push]) --> Changes[Path Filter]
+    Start --> Lint[Lint]
+    Changes --> TestAPI[Test API when api/shared changed]
+    Changes --> TestFE[Test Frontend when frontend/shared changed]
+    Lint --> TestAPI
+    Lint --> TestFE
     TestAPI --> End([Ready to Merge])
     TestFE --> End
 ```
@@ -52,8 +66,12 @@ The entire platform is orchestrated as a single, cohesive unit on Azure.
 ```mermaid
 graph TD
     Main([Merge to Main]) --> Tofu[OpenTofu: Apply Infra]
-    Tofu --> DeployAPI[Zip Deploy: API]
-    Tofu --> DeployUI[Zip Deploy: Frontend]
+    Tofu --> BuildAPI[Build Shared + API]
+    Tofu --> BuildUI[Build Shared + Frontend]
+    BuildAPI --> PackageAPI[Create api-deploy.zip]
+    BuildUI --> PackageUI[Create frontend-deploy.zip]
+    PackageAPI --> DeployAPI[Zip Deploy: Azure Functions]
+    PackageUI --> DeployUI[Zip Deploy: Azure Web App]
     DeployAPI --> Live((Live App))
     DeployUI --> Live
 ```

--- a/frontend/src/app/evolution/content.ts
+++ b/frontend/src/app/evolution/content.ts
@@ -162,10 +162,11 @@ export const chapters: Chapter[] = [
 			"Standardized infrastructure management using Terraform (OpenTofu) to achieve full environmental sovereignty. Transitioned to a codified architecture to ensure deterministic deployments and eliminate configuration drift.",
 		timeline: [
 			{
-				date: "2026-04-09",
-				title: "Terraform IaC Orchestration",
+				date: "2026-04-08",
+				title: "ADR 007: Infrastructure as Code for Azure Cloud Services",
 				description:
-					"Architected a codified platform using Terraform, replacing manual or provider-abstracted deployments with a deterministic Infrastructure-as-Code (IaC) model. This structural upgrade ensures a stable deployment lifecycle and establishes a resilient, multi-stage CI/CD pipeline for the entire platform.",
+					"Architected a codified Azure platform using OpenTofu, replacing manual cloud configuration with a deterministic Infrastructure-as-Code (IaC) model for Azure Functions, Azure Web App, storage, Application Insights, and deployment configuration.",
+				adrPath: "007-infrastructure-as-code-azure-cloud-services",
 			},
 		],
 	},


### PR DESCRIPTION
### Summary

This change strengthens the project documentation by adding a clear documentation map, architecture index, incident reports, and an IaC-focused ADR. It also aligns the operations guide and evolution timeline with the current OpenTofu and Azure deployment model.

### List of Changes

- Improved documentation discoverability by linking architecture, operations, ADRs, and RCA reports from the main README and docs index.
- Captured resolved operational lessons in incident reports and added ADR 007 to explain the migration to Infrastructure as Code for Azure cloud services.
- Updated operations and evolution content so reviewers can trace how CI/CD, Azure deployment, and IaC decisions fit together.

### Verification

- [x] Review the README Documentation Map and confirm each link points to the intended docs section.
- [x] Review the new architecture index and confirm it accurately represents the frontend/backend split.
- [x] Review the incident reports and confirm the RCA summaries match the resolved fixes.
- [x] Review ADR 007 and confirm it accurately describes the OpenTofu Azure IaC migration.

