### PR TITLE
fix(api): configure bulk function key

### DIFF
--- a/frontend/src/app/api/_utils/generateImages.test.ts
+++ b/frontend/src/app/api/_utils/generateImages.test.ts
@@ -9,6 +9,7 @@ describe("proxyGenerateImages", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		process.env.AZURE_FUNCTION_URL = "http://mock-api";
+		process.env.AZURE_FUNCTION_KEY = "test-key";
 	});
 
 	it("forwards batch payload to backend API", async () => {
@@ -34,10 +35,19 @@ describe("proxyGenerateImages", () => {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				"x-functions-key": "",
+				"x-functions-key": "test-key",
 			},
 			body: JSON.stringify(body),
 		});
 		expect(response).toBe(fakeResponse);
+	});
+
+	it("throws when API URL is missing", async () => {
+		delete process.env.AZURE_FUNCTION_URL;
+
+		await expect(proxyGenerateImages([])).rejects.toThrow(
+			"Azure Functions API URL is missing for batch generation.",
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/app/api/_utils/generateImages.ts
+++ b/frontend/src/app/api/_utils/generateImages.ts
@@ -6,6 +6,10 @@ import type { ImageParams } from "@cover-craft/shared";
 export async function proxyGenerateImages(body: ImageParams[]) {
 	const API_URL = process.env.AZURE_FUNCTION_URL;
 	const API_KEY = process.env.AZURE_FUNCTION_KEY;
+	if (!API_URL) {
+		throw new Error("Azure Functions API URL is missing for batch generation.");
+	}
+
 	const response = await fetch(`${API_URL}/generateImages`, {
 		method: "POST",
 		headers: {

--- a/frontend/src/app/api/_utils/jobStatus.test.ts
+++ b/frontend/src/app/api/_utils/jobStatus.test.ts
@@ -9,6 +9,7 @@ describe("proxyJobStatus", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		process.env.AZURE_FUNCTION_URL = "http://mock-api";
+		process.env.AZURE_FUNCTION_KEY = "test-key";
 	});
 
 	it("calls backend getJobStatus with jobId", async () => {
@@ -23,10 +24,19 @@ describe("proxyJobStatus", () => {
 			"http://mock-api/getJobStatus?jobId=job-123",
 			{
 				headers: {
-					"x-functions-key": "",
+					"x-functions-key": "test-key",
 				},
 			},
 		);
 		expect(response).toBe(fakeResponse);
+	});
+
+	it("throws when API URL is missing", async () => {
+		delete process.env.AZURE_FUNCTION_URL;
+
+		await expect(proxyJobStatus("job-123")).rejects.toThrow(
+			"Azure Functions API URL is missing for job status polling.",
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });

--- a/frontend/src/app/api/_utils/jobStatus.ts
+++ b/frontend/src/app/api/_utils/jobStatus.ts
@@ -4,6 +4,12 @@
 export async function proxyJobStatus(jobId: string) {
 	const API_URL = process.env.AZURE_FUNCTION_URL;
 	const API_KEY = process.env.AZURE_FUNCTION_KEY;
+	if (!API_URL) {
+		throw new Error(
+			"Azure Functions API URL is missing for job status polling.",
+		);
+	}
+
 	const response = await fetch(`${API_URL}/getJobStatus?jobId=${jobId}`, {
 		headers: {
 			"x-functions-key": API_KEY || "",

--- a/frontend/src/components/form/CoverForm.test.tsx
+++ b/frontend/src/components/form/CoverForm.test.tsx
@@ -1,3 +1,4 @@
+import type { ImageParams } from "@cover-craft/shared";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import CoverForm from "./CoverForm";
@@ -13,7 +14,7 @@ vi.mock("@/hooks", async () => {
 
 // Mock PreviewCanvas to avoid canvas issues in tests and make params testable
 vi.mock("./PreviewCanvas", () => ({
-	PreviewCanvas: ({ params }: { params: any }) => (
+	PreviewCanvas: ({ params }: { params: ImageParams }) => (
 		<div data-testid="preview-canvas">
 			<span>{params.title || "Title Preview"}</span>
 			<span>{params.subtitle || "Subtitle Preview"}</span>

--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -75,16 +75,7 @@ module "application_insights" {
   tags                = local.tags
 }
 
-# 3. App Service Module (Plan & Frontend)
-module "app_service" {
-  source              = "./modules/app_service"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = var.location
-  app_name            = var.app_name
-  tags                = local.tags
-}
-
-# 4. Function App Module (API)
+# 3. Function App Module (API)
 module "function_app" {
   source                           = "./modules/function_app"
   resource_group_name              = azurerm_resource_group.api.name
@@ -98,4 +89,21 @@ module "function_app" {
   app_insights_connection_string   = module.application_insights.connection_string
   app_insights_instrumentation_key = module.application_insights.instrumentation_key
   tags                             = local.tags
+}
+
+data "azurerm_function_app_host_keys" "api" {
+  name                = var.app_name
+  resource_group_name = azurerm_resource_group.api.name
+
+  depends_on = [module.function_app]
+}
+
+# 4. App Service Module (Plan & Frontend)
+module "app_service" {
+  source              = "./modules/app_service"
+  resource_group_name = data.azurerm_resource_group.main.name
+  location            = var.location
+  app_name            = var.app_name
+  azure_function_key  = data.azurerm_function_app_host_keys.api.default_function_key
+  tags                = local.tags
 }

--- a/tofu/modules/app_service/main.tf
+++ b/tofu/modules/app_service/main.tf
@@ -10,6 +10,11 @@ variable "app_name" {
   type = string
 }
 
+variable "azure_function_key" {
+  type      = string
+  sensitive = true
+}
+
 variable "tags" {
   type    = map(string)
   default = {}
@@ -40,6 +45,7 @@ resource "azurerm_linux_web_app" "frontend" {
 
   app_settings = {
     "AZURE_FUNCTION_URL" = "https://${var.app_name}.azurewebsites.net/api"
+    "AZURE_FUNCTION_KEY" = var.azure_function_key
     "NODE_ENV"           = "production"
   }
 }

--- a/tofu/modules/function_app/main.tf
+++ b/tofu/modules/function_app/main.tf
@@ -45,8 +45,8 @@ variable "tags" {
 
 # 1. Storage Container for Flex Consumption Deployment
 resource "azurerm_storage_container" "deploy" {
-  name                 = "app-package"
-  storage_account_id   = var.storage_account_id
+  name                  = "app-package"
+  storage_account_id    = var.storage_account_id
   container_access_type = "private"
 }
 
@@ -73,10 +73,10 @@ resource "azurerm_function_app_flex_consumption" "api" {
   runtime_name    = "node"
   runtime_version = "22"
 
-  storage_container_type           = "blobContainer"
-  storage_container_endpoint       = "${var.storage_container_endpoint}${azurerm_storage_container.deploy.name}"
-  storage_authentication_type      = "StorageAccountConnectionString"
-  storage_access_key               = var.storage_account_access_key
+  storage_container_type      = "blobContainer"
+  storage_container_endpoint  = "${var.storage_container_endpoint}${azurerm_storage_container.deploy.name}"
+  storage_authentication_type = "StorageAccountConnectionString"
+  storage_access_key          = var.storage_account_access_key
 
   site_config {
     app_service_logs {


### PR DESCRIPTION
### Summary
Bulk image generation was failing because the frontend BFF called function-authenticated Azure Functions without a configured function key in the deployed Web App. This change wires the Function App host key into the frontend app settings and improves proxy errors when the Azure Functions URL is missing.

### List of Changes
- Restored authenticated bulk generation by passing the Azure Functions key into the frontend App Service configuration.
- Made batch submission and job polling easier to diagnose by adding explicit proxy configuration checks and coverage for authenticated requests.

### Verification
- [x] `npm test --workspace=frontend -- --run src/app/api/_utils/generateImages.test.ts src/app/api/_utils/jobStatus.test.ts`
- [x] `npm test --workspace=api -- --run src/functions/generateImages.test.ts src/functions/getJobStatus.test.ts src/functions/processJobs.test.ts`
- [x] `npm run lint:api`
- [x] `npm run lint:frontend`
- [x] `tofu fmt -check -recursive tofu`
- [x] Run `tofu validate` in an environment where the azurerm provider plugin can start successfully.

