### PR TITLE
fix(shared): switch tsconfig to Node16 module settings

### DIFF
--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -3,8 +3,8 @@
 	"compilerOptions": {
 		"composite": true,
 		"target": "ES2020",
-		"module": "CommonJS",
-		"moduleResolution": "Node",
+		"module": "Node16",
+		"moduleResolution": "node16",
 		"declaration": true,
 		"declarationMap": true,
 		"skipLibCheck": true,


### PR DESCRIPTION
### Summary
This change updates the shared TypeScript configuration to use modern Node 16 module settings required by TypeScript 6. It resolves build failures caused by legacy Node module resolution behavior and keeps the shared package aligned with current compiler expectations.

### List of Changes
- Updated `shared/tsconfig.json` to `module: "Node16"` and `moduleResolution: "node16"` so shared builds work with TypeScript 6 without deprecation errors.
- Improved dependency update reliability by removing a compiler config mismatch that would otherwise cause CI and local shared builds to fail.

### Verification
- [x] `npm run build:shared`

