### PR TITLE
feat(api): add resilient batch job retries

### DIFF
--- a/api/src/functions/generateImages.test.ts
+++ b/api/src/functions/generateImages.test.ts
@@ -161,6 +161,9 @@ describe("generateImages", () => {
 		expect(mocks.mockJobCreate).toHaveBeenCalledWith(
 			expect.objectContaining({
 				status: JOB_STATUS_PENDING,
+				attempts: 0,
+				maxAttempts: 3,
+				resultDetails: {},
 			}),
 		);
 		expect(mocks.mockStoreMetrics).not.toHaveBeenCalled();

--- a/api/src/functions/generateImages.ts
+++ b/api/src/functions/generateImages.ts
@@ -17,6 +17,8 @@ import { createLogger } from "../lib/logger";
 import { connectMongoDB, getJobModel } from "../lib/mongoose";
 import { buildMetricPayload, storeMetricsToMongoDB } from "./metrics";
 
+const DEFAULT_MAX_JOB_ATTEMPTS = 3;
+
 export const generateImages: HttpHandler = async (
 	request: HttpRequest,
 	context: InvocationContext,
@@ -103,6 +105,9 @@ export const generateImages: HttpHandler = async (
 			status: JOB_STATUS_PENDING,
 			requests: requests as unknown as Record<string, unknown>[],
 			results: [],
+			attempts: 0,
+			maxAttempts: DEFAULT_MAX_JOB_ATTEMPTS,
+			resultDetails: {},
 		});
 
 		logger.info("Provisioned pending batch job", {

--- a/api/src/functions/getJobStatus.test.ts
+++ b/api/src/functions/getJobStatus.test.ts
@@ -110,6 +110,52 @@ describe("getJobStatus", () => {
 		expect(mocks.mockJobFindById).toHaveBeenCalledWith(fullId);
 	});
 
+	it("should return public string results from structured job result details", async () => {
+		const fullId = "69a0f2db7b65847194bf1aec";
+		const mockRequest = {
+			query: new Map([["jobId", fullId]]),
+		} as unknown as HttpRequest;
+
+		const mockJob = {
+			_id: fullId,
+			status: JOB_STATUS_PENDING,
+			requests: [{}, {}],
+			results: [],
+			resultDetails: {
+				"1": {
+					index: 1,
+					status: "error",
+					error: "failed",
+					attempts: 3,
+					updatedAt: new Date(),
+				},
+				"0": {
+					index: 0,
+					status: "success",
+					dataUrl: "data:image/png;base64,img1",
+					attempts: 1,
+					updatedAt: new Date(),
+				},
+			},
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+		mocks.mockJobFindById.mockResolvedValue(mockJob);
+
+		const response = (await getJobStatus(
+			mockRequest,
+			mockContext,
+		)) as HttpResponseInit;
+
+		expect(response.status).toBe(200);
+		expect(response.jsonBody).toEqual(
+			expect.objectContaining({
+				progress: 2,
+				results: ["data:image/png;base64,img1", "error: failed"],
+			}),
+		);
+	});
+
 	it("should return 200 with partial jobId (8 chars) if found", async () => {
 		const partialId = "94bf1aec";
 		const mockRequest = {

--- a/api/src/functions/getJobStatus.ts
+++ b/api/src/functions/getJobStatus.ts
@@ -6,10 +6,37 @@ import {
 } from "@azure/functions";
 import type { Types } from "mongoose";
 import { createLogger } from "../lib/logger";
-import { connectMongoDB, getJobModel, type JobDocument } from "../lib/mongoose";
+import {
+	connectMongoDB,
+	getJobModel,
+	type JobDocument,
+	type JobResult,
+} from "../lib/mongoose";
 
 interface JobWithId extends JobDocument {
 	_id: Types.ObjectId;
+}
+
+function publicResultFromDetail(detail: JobResult): string {
+	if (detail.status === "success" && detail.dataUrl) {
+		return detail.dataUrl;
+	}
+
+	return `error: ${detail.error || "Failed to render"}`;
+}
+
+function getFinalResults(job: JobDocument): string[] {
+	const resultDetails = job.resultDetails ?? {};
+	const detailKeys = Object.keys(resultDetails);
+
+	if (detailKeys.length === 0) {
+		return job.results ?? [];
+	}
+
+	return detailKeys
+		.map((key) => resultDetails[key])
+		.sort((a, b) => a.index - b.index)
+		.map(publicResultFromDetail);
 }
 
 export async function getJobStatus(
@@ -73,14 +100,16 @@ export async function getJobStatus(
 
 		logger.info("Retrieved job status", { jobId, status: job.status });
 
+		const results = getFinalResults(job);
+
 		return {
 			status: 200,
 			jsonBody: {
 				id: job._id.toString(),
 				status: job.status,
-				progress: job.results.length,
+				progress: results.length,
 				total: job.requests.length,
-				results: job.results,
+				results,
 				error: job.error,
 				createdAt: job.createdAt,
 				updatedAt: job.updatedAt,

--- a/api/src/functions/processJobs.test.ts
+++ b/api/src/functions/processJobs.test.ts
@@ -1,6 +1,7 @@
 import type { InvocationContext } from "@azure/functions";
 import {
 	JOB_STATUS_COMPLETED,
+	JOB_STATUS_FAILED,
 	JOB_STATUS_PROCESSING,
 } from "@cover-craft/shared";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,6 +11,7 @@ const mocks = vi.hoisted(() => {
 	return {
 		mockJobFindOneAndUpdate: vi.fn(),
 		mockJobFindByIdAndUpdate: vi.fn(),
+		mockJobFindById: vi.fn(),
 		mockLogCreate: vi.fn(),
 		mockGeneratePNG: vi.fn().mockResolvedValue(Buffer.from("fake-png")),
 		mockStoreMetrics: vi.fn(),
@@ -21,6 +23,7 @@ vi.mock("../lib/mongoose", () => {
 	const mockJobModel = {
 		findOneAndUpdate: mocks.mockJobFindOneAndUpdate,
 		findByIdAndUpdate: mocks.mockJobFindByIdAndUpdate,
+		findById: mocks.mockJobFindById,
 	};
 	const mockLogModel = { create: mocks.mockLogCreate };
 	return {
@@ -51,6 +54,7 @@ describe("processJobs", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mocks.mockGeneratePNG.mockResolvedValue(Buffer.from("fake-png"));
 	});
 
 	it("should process a job successfully", async () => {
@@ -67,6 +71,7 @@ describe("processJobs", () => {
 					font: "Inter",
 				},
 			],
+			resultDetails: {},
 		};
 
 		mocks.mockJobFindOneAndUpdate.mockResolvedValue(mockJob);
@@ -74,16 +79,150 @@ describe("processJobs", () => {
 		await processJobs(jobId, mockContext);
 
 		expect(mocks.mockJobFindOneAndUpdate).toHaveBeenCalledWith(
-			{ _id: jobId, status: "pending" },
-			{ $set: { status: JOB_STATUS_PROCESSING } },
+			expect.objectContaining({
+				_id: jobId,
+				$or: expect.arrayContaining([
+					expect.objectContaining({ status: "pending" }),
+					expect.objectContaining({ status: JOB_STATUS_PROCESSING }),
+				]),
+			}),
+			expect.objectContaining({
+				$set: expect.objectContaining({
+					status: JOB_STATUS_PROCESSING,
+					processingStartedAt: expect.any(Date),
+				}),
+				$inc: { attempts: 1 },
+			}),
 			{ new: true },
 		);
 		expect(mocks.mockGeneratePNG).toHaveBeenCalled();
 		expect(mocks.mockJobFindByIdAndUpdate).toHaveBeenCalledWith(jobId, {
 			$set: expect.objectContaining({
+				"resultDetails.0": expect.objectContaining({
+					index: 0,
+					status: "success",
+					attempts: 1,
+				}),
+				"results.0": expect.stringContaining("data:image/png;base64,"),
+			}),
+		});
+		expect(mocks.mockJobFindByIdAndUpdate).toHaveBeenCalledWith(jobId, {
+			$set: expect.objectContaining({
 				status: JOB_STATUS_COMPLETED,
+			}),
+			$unset: expect.objectContaining({
+				processingStartedAt: "",
 			}),
 		});
 		expect(mocks.mockStoreMetrics).toHaveBeenCalled();
+	});
+
+	it("should retry an image render before storing the final result", async () => {
+		const jobId = "test-job-id";
+		const mockJob = {
+			_id: jobId,
+			requests: [
+				{
+					title: "Test",
+					width: 800,
+					height: 600,
+					backgroundColor: "#000",
+					textColor: "#fff",
+					font: "Inter",
+				},
+			],
+			resultDetails: {},
+		};
+
+		mocks.mockJobFindOneAndUpdate.mockResolvedValue(mockJob);
+		mocks.mockGeneratePNG
+			.mockRejectedValueOnce(new Error("temporary canvas failure"))
+			.mockResolvedValueOnce(Buffer.from("fake-png"));
+
+		await processJobs(jobId, mockContext);
+
+		expect(mocks.mockGeneratePNG).toHaveBeenCalledTimes(2);
+		expect(mocks.mockJobFindByIdAndUpdate).toHaveBeenCalledWith(jobId, {
+			$set: expect.objectContaining({
+				"resultDetails.0": expect.objectContaining({
+					status: "success",
+					attempts: 2,
+				}),
+			}),
+		});
+	});
+
+	it("should skip image indexes that already have final results", async () => {
+		const jobId = "test-job-id";
+		const existingDetail = {
+			index: 0,
+			status: "success" as const,
+			dataUrl: "data:image/png;base64,existing",
+			attempts: 1,
+			updatedAt: new Date(),
+		};
+		const mockJob = {
+			_id: jobId,
+			requests: [
+				{
+					title: "Test",
+					width: 800,
+					height: 600,
+					backgroundColor: "#000",
+					textColor: "#fff",
+					font: "Inter",
+				},
+			],
+			resultDetails: { "0": existingDetail },
+		};
+
+		mocks.mockJobFindOneAndUpdate.mockResolvedValue(mockJob);
+
+		await processJobs(jobId, mockContext);
+
+		expect(mocks.mockGeneratePNG).not.toHaveBeenCalled();
+		expect(mocks.mockJobFindByIdAndUpdate).toHaveBeenCalledWith(jobId, {
+			$set: expect.objectContaining({
+				status: JOB_STATUS_COMPLETED,
+				results: ["data:image/png;base64,existing"],
+			}),
+			$unset: expect.objectContaining({
+				processingStartedAt: "",
+			}),
+		});
+	});
+
+	it("should fail the job when all image attempts fail", async () => {
+		const jobId = "test-job-id";
+		const mockJob = {
+			_id: jobId,
+			requests: [
+				{
+					title: "Test",
+					width: 800,
+					height: 600,
+					backgroundColor: "#000",
+					textColor: "#fff",
+					font: "Inter",
+				},
+			],
+			resultDetails: {},
+		};
+
+		mocks.mockJobFindOneAndUpdate.mockResolvedValue(mockJob);
+		mocks.mockGeneratePNG.mockRejectedValue(new Error("canvas failed"));
+
+		await processJobs(jobId, mockContext);
+
+		expect(mocks.mockGeneratePNG).toHaveBeenCalledTimes(3);
+		expect(mocks.mockJobFindByIdAndUpdate).toHaveBeenCalledWith(jobId, {
+			$set: expect.objectContaining({
+				status: JOB_STATUS_FAILED,
+				error: "All images failed to generate.",
+			}),
+			$unset: expect.objectContaining({
+				processingStartedAt: "",
+			}),
+		});
 	});
 });

--- a/api/src/functions/processJobs.ts
+++ b/api/src/functions/processJobs.ts
@@ -6,14 +6,97 @@ import {
 	type ImageParams,
 	JOB_STATUS_COMPLETED,
 	JOB_STATUS_FAILED,
+	JOB_STATUS_PENDING,
 	JOB_STATUS_PROCESSING,
 	METRIC_STATUS_ERROR,
 	METRIC_STATUS_SUCCESS,
 } from "@cover-craft/shared";
 import { createLogger } from "../lib/logger";
-import { connectMongoDB, getJobModel } from "../lib/mongoose";
+import {
+	connectMongoDB,
+	getJobModel,
+	type JobDocument,
+	type JobResult,
+} from "../lib/mongoose";
 import { generatePNG } from "../services/imageService";
 import { buildMetricPayload, storeMetricsToMongoDB } from "./metrics";
+
+const DEFAULT_MAX_JOB_ATTEMPTS = 3;
+const MAX_IMAGE_ATTEMPTS = 3;
+const PROCESSING_TIMEOUT_MS = 5 * 60 * 1000;
+const JOB_RETRY_VISIBILITY_TIMEOUT_SECONDS = 30;
+const IMAGE_RETRY_BASE_DELAY_MS = 250;
+const IMAGE_RETRY_JITTER_MS = 100;
+
+function getJobResultMap(job: JobDocument): Record<string, JobResult> {
+	return job.resultDetails ?? {};
+}
+
+function publicResultFromDetail(detail: JobResult): string {
+	if (detail.status === "success" && detail.dataUrl) {
+		return detail.dataUrl;
+	}
+
+	return `error: ${detail.error || "Failed to render"}`;
+}
+
+function buildPublicResults(
+	resultDetails: Record<string, JobResult>,
+	total: number,
+): string[] {
+	const publicResults: string[] = [];
+
+	for (let i = 0; i < total; i++) {
+		const detail = resultDetails[String(i)];
+		if (detail) {
+			publicResults[i] = publicResultFromDetail(detail);
+		}
+	}
+
+	return publicResults;
+}
+
+function countFinalResults(resultDetails: Record<string, JobResult>): number {
+	return Object.keys(resultDetails).length;
+}
+
+function hasSuccessfulResult(
+	resultDetails: Record<string, JobResult>,
+): boolean {
+	return Object.values(resultDetails).some(
+		(detail) => detail.status === "success",
+	);
+}
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function getRetryDelay(attempt: number): number {
+	const exponentialDelay =
+		IMAGE_RETRY_BASE_DELAY_MS * 2 ** Math.max(0, attempt - 1);
+	const jitter = Math.floor(Math.random() * (IMAGE_RETRY_JITTER_MS + 1));
+	return exponentialDelay + jitter;
+}
+
+async function wait(ms: number): Promise<void> {
+	await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function enqueueJobRetry(jobId: string): Promise<void> {
+	const storageConnectionString = process.env.AzureWebJobsStorage;
+	if (!storageConnectionString) {
+		return;
+	}
+
+	const { QueueClient } = await import("@azure/storage-queue");
+	const queueClient = new QueueClient(storageConnectionString, "batch-jobs");
+	await queueClient.createIfNotExists();
+	const base64Message = Buffer.from(jobId).toString("base64");
+	await queueClient.sendMessage(base64Message, {
+		visibilityTimeout: JOB_RETRY_VISIBILITY_TIMEOUT_SECONDS,
+	});
+}
 
 export async function processJobs(
 	queueItem: unknown,
@@ -31,15 +114,56 @@ export async function processJobs(
 
 		logger.info("Attempting to claim lock on Job", { jobId: jobIdStr });
 
-		// Atomically find the job AND change its status from pending to processing
+		const staleBefore = new Date(Date.now() - PROCESSING_TIMEOUT_MS);
+		const claimableAttempts = [
+			{ attempts: { $exists: false } },
+			{ attempts: { $lt: DEFAULT_MAX_JOB_ATTEMPTS } },
+		];
+
+		// Atomically claim a new job or reclaim a stale processing job.
 		const job = await Job.findOneAndUpdate(
-			{ _id: jobIdStr, status: "pending" },
-			{ $set: { status: JOB_STATUS_PROCESSING } },
+			{
+				_id: jobIdStr,
+				$or: [
+					{ status: JOB_STATUS_PENDING, $or: claimableAttempts },
+					{
+						status: JOB_STATUS_PROCESSING,
+						processingStartedAt: { $lt: staleBefore },
+						$or: claimableAttempts,
+					},
+				],
+			},
+			{
+				$set: {
+					status: JOB_STATUS_PROCESSING,
+					processingStartedAt: new Date(),
+					maxAttempts: DEFAULT_MAX_JOB_ATTEMPTS,
+				},
+				$inc: { attempts: 1 },
+			},
 			{ new: true },
 		);
 
 		if (!job) {
-			logger.warn("Job not found or already processed/failed", {
+			const existingJob = await Job.findById(jobIdStr);
+			if (
+				existingJob &&
+				existingJob.status !== JOB_STATUS_COMPLETED &&
+				existingJob.status !== JOB_STATUS_FAILED &&
+				(existingJob.attempts ?? 0) >=
+					(existingJob.maxAttempts ?? DEFAULT_MAX_JOB_ATTEMPTS)
+			) {
+				await Job.findByIdAndUpdate(jobIdStr, {
+					$set: {
+						status: JOB_STATUS_FAILED,
+						error: "Job exceeded maximum processing attempts.",
+						lastError: "Job exceeded maximum processing attempts.",
+					},
+					$unset: { processingStartedAt: "" },
+				});
+			}
+
+			logger.warn("Job not found, already finalized, or actively processing", {
 				jobId: jobIdStr,
 			});
 			return;
@@ -50,62 +174,93 @@ export async function processJobs(
 			requestCount: job.requests.length,
 		});
 
-		const generatedBase64s: string[] = [];
-		const errors: Error[] = [];
+		const resultDetails = { ...getJobResultMap(job) };
 
 		for (let i = 0; i < job.requests.length; i++) {
+			if (resultDetails[String(i)]) {
+				logger.info("Skipping already finalized image result", {
+					jobId: jobIdStr,
+					index: i,
+				});
+				continue;
+			}
+
 			const currentRequest = job.requests[i] as unknown as ImageParams;
 			const startTime = performance.now();
+			let lastError: unknown;
+			let detail: JobResult | null = null;
 
-			try {
-				const pngBuffer = await generatePNG(currentRequest);
-				const duration = Math.round(performance.now() - startTime);
-
-				const base64Data = `data:image/png;base64,${pngBuffer.toString("base64")}`;
-				generatedBase64s.push(base64Data);
-
-				// Capture individual Success Metrics
+			for (let attempt = 1; attempt <= MAX_IMAGE_ATTEMPTS; attempt++) {
 				try {
-					const contrastRatio = getContrastRatio(
-						currentRequest.backgroundColor || "#FFFFFF",
-						currentRequest.textColor || "#000000",
-					);
-					await storeMetricsToMongoDB(
-						buildMetricPayload(METRIC_STATUS_SUCCESS, {
-							duration,
-							size: {
-								width: currentRequest.width,
-								height: currentRequest.height,
-							},
-							font: currentRequest.font,
-							titleLength: currentRequest.title?.length || 0,
-							subtitleLength: currentRequest.subtitle?.length || 0,
-							contrastRatio: contrastRatio ?? undefined,
-							wcagLevel:
-								contrastRatio !== null
-									? getWCAGLevelFromRatio(contrastRatio)
-									: undefined,
-						}),
-						context,
-					);
-				} catch (mErr) {
-					logger.warn(`Failed to store success metric for image index ${i}`, {
-						error: mErr,
+					const pngBuffer = await generatePNG(currentRequest);
+					const duration = Math.round(performance.now() - startTime);
+
+					const base64Data = `data:image/png;base64,${pngBuffer.toString("base64")}`;
+					detail = {
+						index: i,
+						status: "success",
+						dataUrl: base64Data,
+						attempts: attempt,
+						updatedAt: new Date(),
+					};
+
+					try {
+						const contrastRatio = getContrastRatio(
+							currentRequest.backgroundColor || "#FFFFFF",
+							currentRequest.textColor || "#000000",
+						);
+						await storeMetricsToMongoDB(
+							buildMetricPayload(METRIC_STATUS_SUCCESS, {
+								duration,
+								size: {
+									width: currentRequest.width,
+									height: currentRequest.height,
+								},
+								font: currentRequest.font,
+								titleLength: currentRequest.title?.length || 0,
+								subtitleLength: currentRequest.subtitle?.length || 0,
+								contrastRatio: contrastRatio ?? undefined,
+								wcagLevel:
+									contrastRatio !== null
+										? getWCAGLevelFromRatio(contrastRatio)
+										: undefined,
+							}),
+							context,
+						);
+					} catch (mErr) {
+						logger.warn(`Failed to store success metric for image index ${i}`, {
+							error: mErr,
+						});
+					}
+					break;
+				} catch (err) {
+					lastError = err;
+					logger.warn("Image render attempt failed", {
+						jobId: jobIdStr,
+						index: i,
+						attempt,
+						error: getErrorMessage(err),
 					});
+
+					if (attempt < MAX_IMAGE_ATTEMPTS) {
+						await wait(getRetryDelay(attempt));
+					}
 				}
-			} catch (err) {
+			}
+
+			if (!detail) {
 				const duration = Math.round(performance.now() - startTime);
-				logger.error(
-					`Failed to generate image index ${i} for job ${jobIdStr}`,
-					err,
-				);
+				const errorMessage = lastError
+					? getErrorMessage(lastError)
+					: "Failed to render";
+				detail = {
+					index: i,
+					status: "error",
+					error: errorMessage,
+					attempts: MAX_IMAGE_ATTEMPTS,
+					updatedAt: new Date(),
+				};
 
-				generatedBase64s.push(
-					`error: ${err instanceof Error ? err.message : "Failed to render"}`,
-				);
-				errors.push(err instanceof Error ? err : new Error(String(err)));
-
-				// Capture individual Error Metrics
 				try {
 					const contrastRatio = getContrastRatio(
 						currentRequest.backgroundColor || "#FFFFFF",
@@ -126,7 +281,7 @@ export async function processJobs(
 								contrastRatio !== null
 									? getWCAGLevelFromRatio(contrastRatio)
 									: undefined,
-							errorMessage: err instanceof Error ? err.message : String(err),
+							errorMessage,
 						}),
 						context,
 					);
@@ -136,22 +291,45 @@ export async function processJobs(
 					});
 				}
 			}
+
+			resultDetails[String(i)] = detail;
+			await Job.findByIdAndUpdate(jobIdStr, {
+				$set: {
+					[`resultDetails.${i}`]: detail,
+					[`results.${i}`]: publicResultFromDetail(detail),
+					...(detail.status === "error" ? { lastError: detail.error } : {}),
+				},
+			});
 		}
 
-		const hasFatalErrors = errors.length === job.requests.length;
+		const processedCount = countFinalResults(resultDetails);
+		const allImagesFinal = processedCount === job.requests.length;
+		const hasSuccess = hasSuccessfulResult(resultDetails);
+		const finalStatus =
+			allImagesFinal && hasSuccess ? JOB_STATUS_COMPLETED : JOB_STATUS_FAILED;
+		const finalError = hasSuccess
+			? undefined
+			: "All images failed to generate.";
 
 		await Job.findByIdAndUpdate(jobIdStr, {
 			$set: {
-				status: hasFatalErrors ? JOB_STATUS_FAILED : JOB_STATUS_COMPLETED,
-				results: generatedBase64s,
-				error: hasFatalErrors ? "All images failed to generate." : undefined,
+				status: finalStatus,
+				results: buildPublicResults(resultDetails, job.requests.length),
+				...(finalError ? { error: finalError } : {}),
+				...(finalError ? { lastError: finalError } : {}),
+			},
+			$unset: {
+				processingStartedAt: "",
+				...(finalError ? {} : { error: "", lastError: "" }),
 			},
 		});
 
 		logger.info("Batch job finished", {
 			jobId: jobIdStr,
-			processed: job.requests.length,
-			errors: errors.length,
+			processed: processedCount,
+			errors: Object.values(resultDetails).filter(
+				(detail) => detail.status === "error",
+			).length,
 		});
 	} catch (globalError: unknown) {
 		logger.error("CRITICAL ERROR processing queue", globalError);
@@ -159,14 +337,30 @@ export async function processJobs(
 		try {
 			const Job = getJobModel();
 			const jobIdStr = String(queueItem);
+			const existingJob = await Job.findById(jobIdStr);
+			const maxAttempts = existingJob?.maxAttempts ?? DEFAULT_MAX_JOB_ATTEMPTS;
+			const attempts = existingJob?.attempts ?? maxAttempts;
+			const errorMessage = getErrorMessage(globalError);
+
+			if (attempts < maxAttempts) {
+				await Job.findByIdAndUpdate(jobIdStr, {
+					$set: {
+						status: JOB_STATUS_PENDING,
+						lastError: errorMessage,
+					},
+					$unset: { processingStartedAt: "" },
+				});
+				await enqueueJobRetry(jobIdStr);
+				return;
+			}
+
 			await Job.findByIdAndUpdate(jobIdStr, {
 				$set: {
 					status: JOB_STATUS_FAILED,
-					error:
-						globalError instanceof Error
-							? globalError.message
-							: "Crash during worker execution.",
+					error: errorMessage || "Crash during worker execution.",
+					lastError: errorMessage || "Crash during worker execution.",
 				},
+				$unset: { processingStartedAt: "" },
 			});
 		} catch (dbErr) {
 			logger.error("Failed to write critical error recovery to DB", dbErr);

--- a/api/src/lib/mongoose.ts
+++ b/api/src/lib/mongoose.ts
@@ -68,7 +68,21 @@ export interface JobDocument {
 	requests: Record<string, unknown>[];
 	results: string[];
 	error?: string;
+	attempts: number;
+	maxAttempts: number;
+	processingStartedAt?: Date;
+	lastError?: string;
+	resultDetails: Record<string, JobResult>;
 	createdAt: Date;
+	updatedAt: Date;
+}
+
+export interface JobResult {
+	index: number;
+	status: "success" | "error";
+	dataUrl?: string;
+	error?: string;
+	attempts: number;
 	updatedAt: Date;
 }
 
@@ -89,6 +103,14 @@ export const jobSchema = new mongoose.Schema(
 		requests: { type: [mongoose.Schema.Types.Mixed], required: true },
 		results: { type: [String], default: [] },
 		error: { type: String },
+		attempts: { type: Number, default: 0, required: true },
+		maxAttempts: { type: Number, default: 3, required: true },
+		processingStartedAt: { type: Date },
+		lastError: { type: String },
+		resultDetails: {
+			type: mongoose.Schema.Types.Mixed,
+			default: {},
+		},
 	},
 	{ timestamps: true },
 );


### PR DESCRIPTION
### Summary
Adds bounded retry behavior to the API batch image worker so transient render and worker failures can recover without restarting completed image work. The backend now stores structured per-image result metadata while preserving the existing public `results: string[]` response for the frontend.

### List of Changes
- Improved batch job reliability by tracking job attempts, stale processing locks, per-image attempts, and final image results in MongoDB.
- Made retries safer to review and operate by persisting each image result as it completes, skipping finalized image indexes on retry, and preserving the current job status API shape.

### Verification
- [x] `npm run lint:api`
- [x] `npm test --workspace=api`
- [x] `npm run build --workspace=api`
- [x] Manually run a local batch job through the frontend and confirm polling/download behavior still works.

