### PR TITLE
docs(readme): frame project highlights as case studies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,13 @@ It supports fast single-image generation and queued batch processing, with share
 
 ---
 
-## Highlights
+## Case Studies
 
-| Area | What it demonstrates |
-| :--- | :--- |
-| Background processing | Batch requests return HTTP 202, then move through Azure Queue Storage to a queue-triggered worker |
-| State flow | MongoDB tracks job status from `pending` to `processing`, `completed`, or `failed` |
-| Failure handling | Atomic worker claiming, stale-job recovery, and bounded per-image retries prevent duplicate rendering during transient failures |
-| Progress tracking | The UI polls job status so users can follow batch progress after submission |
-| Accessibility | WCAG contrast validation is part of the image generation workflow |
-| Shared validation | Frontend and backend use shared validators for image parameters and batch requests |
-| Deployment | GitHub Actions and Terraform automation support repeatable Azure deployment |
+| Case Study | Problem | How it was diagnosed | Result |
+| :--- | :--- | :--- | :--- |
+| [Azure Functions monorepo packaging](./docs/incidents/002-azure-functions-monorepo-package-deployment-failure.md) | The API artifact could deploy with a nested zip, missing production dependencies, or missing `@cover-craft/shared` output after the move to a workspace-based monorepo. | Compared the deployed package shape against Azure Functions runtime expectations and the monorepo assumptions captured in [ADR 004](./docs/decisions/004-full-stack-monorepo-orchestration.md). | CI now builds a self-contained API package from the correct root, installs production dependencies locally, and copies shared build output into the artifact. |
+| [Batch API authentication boundary](./docs/incidents/004-batch-api-function-key-authentication-failure.md) | Batch generation and job-status polling failed after Azure Functions endpoints required function-key authentication. | Traced the BFF request path from Next.js route handlers to the secured Azure Functions API, then verified the proxy was missing `x-functions-key` for the architecture described in [ADR 006](./docs/decisions/006-batch-image-generation-architecture.md). | Proxy utilities now forward `AZURE_FUNCTION_KEY` server-side for batch submission and polling while keeping the secret out of the browser. |
+| [Flex Consumption infrastructure migration](./docs/incidents/005-flex-consumption-deployment-configuration-failure.md) | Moving to Azure Functions Flex Consumption and Terraform-managed infrastructure exposed invalid app settings, missing CI authentication, and package execution assumptions. | Traced deployment failures to hosting-plan-specific requirements while implementing the infrastructure model in [ADR 007](./docs/decisions/007-infrastructure-as-code-azure-cloud-services.md). | CI now authenticates infrastructure deployment explicitly, the API runs from package, and incompatible Flex Consumption settings were removed. |
 
 ---
 

--- a/frontend/src/app/evolution/content.ts
+++ b/frontend/src/app/evolution/content.ts
@@ -16,19 +16,19 @@ export const chapters: Chapter[] = [
 	{
 		title: "Inception & Architecture",
 		intro:
-			"Migrated from local Python scripts to a disciplined, cloud-native architecture. Standardized a 'Design-First' foundation and engineered a stateless serverless backend to ensure 99.9% availability and zero-setup deployment.",
+			"Migrated from local Python scripts to a cloud-native application. Established a design-first foundation and moved image generation behind a stateless serverless backend to reduce local setup friction and operational overhead.",
 		timeline: [
 			{
 				date: "2025-04-05",
 				title: "The Beginning: Local Automation",
 				description:
-					"Architected a Python-driven automation tool, resolving local environment bottlenecks and reducing image setup time. While functional, the dependency on local virtual environments highlighted the need for a cloud-native, zero-setup solution.",
+					"Built a Python-driven automation tool to reduce repetitive cover image setup work. The dependency on local virtual environments exposed the need for a browser-based workflow that could run without project-specific machine setup.",
 			},
 			{
 				date: "2025-08-01",
 				title: "Design-First Architecture",
 				description:
-					"Standardized a 'Design-First' methodology to ensure 100% API contract accuracy and data privacy, preventing cross-workspace regressions before implementation.",
+					"Adopted a design-first methodology for API contracts, data models, and privacy constraints. This reduced mid-implementation churn and made later frontend/backend integration easier to reason about.",
 				adrPath: "001-design-first-methodology",
 			},
 			{
@@ -43,25 +43,25 @@ export const chapters: Chapter[] = [
 	{
 		title: "Foundation & Delivery",
 		intro:
-			"Accelerated engineering velocity by establishing a high-performance Next.js architecture and a rigid CI/CD pipeline. Implemented privacy-compliant analytics to drive data-driven optimizations while maintaining 100% WCAG AA compliance.",
+			"Established the Next.js frontend, CI/CD automation, and a privacy-first analytics path. Shared validation and accessibility checks became part of the product workflow instead of after-the-fact review.",
 		timeline: [
 			{
 				date: "2025-10-27",
 				title: "Frontend Architecture & Delivery",
 				description:
-					"Architected the client-side using Next.js for performance and SEO. Established a rigid CI/CD pipeline with GitHub Actions to enforce code quality and automate deployment.",
+					"Built the client application with Next.js App Router and introduced GitHub Actions checks to keep linting, tests, and deployment steps repeatable.",
 			},
 			{
 				date: "2025-11-07",
 				title: "Analytics & Compliance",
 				description:
-					"Designed a privacy-first telemetry system using MongoDB to track user engagement and compliance. Implemented comprehensive testing strategies with Vitest and real-time WCAG checks.",
+					"Added privacy-first telemetry backed by MongoDB and surfaced accessibility signals in the user workflow. Vitest coverage grew around validation, analytics transformation, and UI behavior.",
 			},
 			{
 				date: "2025-12-13",
 				title: "Full-Stack Optimization",
 				description:
-					"Refactored codebase to share validation logic between frontend and backend, ensuring consistency and eliminating duplication bugs. Enhanced the Analytics Dashboard with Recharts for visualizing system performance and user engagement.",
+					"Moved shared validation and data contracts into a common package so the frontend and API could enforce the same rules. Expanded the analytics dashboard with Recharts to visualize usage and accessibility trends.",
 				adrPath: "003-in-app-analytics-strategy",
 			},
 		],
@@ -69,104 +69,128 @@ export const chapters: Chapter[] = [
 	{
 		title: "Launch & Operations",
 		intro:
-			"Hardened the platform for production by implementing structured observability and a unified full-stack monorepo. Resolved systemic deployment bottlenecks, resulting in a self-contained, workspace-aware bundle for guaranteed production integrity.",
+			"Hardened the platform through structured observability, standardized error handling, and a full-stack monorepo. Deployment packaging became explicit so the API could run independently of local workspace assumptions.",
 		timeline: [
 			{
 				date: "2026-01-01",
 				title: "Landing and Evolution Pages Launch",
 				description:
-					"Launched the public landing page and this evolution timeline to transparently share Cover Craft’s journey.",
+					"Launched the public landing page and evolution timeline to document how Cover Craft grew from automation script to production-style application.",
 			},
 			{
 				date: "2026-01-07",
 				title: "Operational Excellence",
 				description:
-					"Transitioned to structured JSON logging with correlation IDs and a centralized MongoDB sink. Standardized error handling across the serverless architecture to ensure production-grade maintainability.",
+					"Introduced structured JSON logging, correlation IDs, and consistent API error responses so operational behavior could be debugged from records instead of guesswork.",
 			},
 			{
 				date: "2026-01-23",
 				title: "Full-Stack Monorepo Orchestration",
 				description:
-					"Unified the entire platform into a cohesive full-stack workspace to improve engineering velocity and system consistency. This structural upgrade ensures all components stay in sync, significantly reducing maintenance overhead while providing a more robust foundation for future growth.",
+					"Unified the frontend, API, and shared package into an npm workspace monorepo. This made cross-stack changes atomic and kept validation logic, types, and tests aligned.",
 				adrPath: "004-full-stack-monorepo-orchestration",
 			},
 			{
 				date: "2026-01-24",
 				title: "Deployment Hardening & Artifact Audit",
 				description:
-					"Conducted a root-cause analysis on deployment artifacts, resolving systemic 404 errors encountered on deployed links by auditing the full deployment lifecycle.",
+					"Audited Azure Functions deployment artifacts after production links failed, then hardened CI packaging around the runtime layout Azure expects.",
 				lessonLearned:
-					"Debugged 404 errors by comparing GitHub and Azure Blob Storage artifacts. This process of elimination revealed that npm workspace symlinking excluded native dependencies (canvas, mongodb) from the function package. Resolved this by hardening the CI/CD workflow to ensure a self-contained, workspace-aware bundle, ensuring deployment integrity.",
+					"Workspace resolution is not the same as deployment packaging. The fix made the API artifact self-contained by installing production dependencies locally and copying the shared package build output into the deployed bundle.",
 			},
 		],
 	},
 	{
 		title: "Design Automation & Color",
 		intro:
-			"Engineered intelligent design automation to balance creative variety with strict accessibility standards. Implemented high-precision benchmarking to ensure zero-latency performance while guaranteeing readable, accessible user content.",
+			"Added design automation that balances creative variety with accessibility. Color randomization now generates readable starting points while preserving manual control.",
 		timeline: [
 			{
 				date: "2026-01-27",
 				title: "ADR 005: Algorithmic Color Randomization",
 				description:
-					"Proposed a randomization system to automate the selection of background and text colors. This architectural decision prioritizes accessibility by embedding WCAG AA compliance checks directly into the selection logic, ensuring that 'random' pairings are readable.",
+					"Documented a randomization system for background and text colors. The decision embedded WCAG contrast checks directly into selection logic so generated pairings start from an accessible baseline.",
 				adrPath: "005-randomize-colors-feature",
 			},
 			{
 				date: "2026-01-29",
 				title: "Accessibility by Design: Color Automation",
 				description:
-					"Engineered and validated a color randomization algorithm that guarantees WCAG AA accessibility, removing the risk of unreadable user content. The final implementation targets a 6.0:1 contrast ratio, ensuring high-quality, readable designs with every click.",
+					"Implemented and validated the color randomization algorithm. The implementation targets a 6.0:1 contrast ratio, exceeding the WCAG AA text threshold while keeping generated designs readable.",
 				lessonLearned:
-					"High-precision benchmarking revealed that a 'brute-force' validation loop for contrast ratios is extremely efficient (~0.03ms per generation), allowing us to prioritize AAA-level accessibility without impacting UI responsiveness.",
+					"Benchmarking showed that a bounded validation loop is fast enough for interaction-scale use, with 6.0:1 pair generation averaging roughly 0.03ms in the documented test run.",
 			},
 		],
 	},
 	{
 		title: "UX Refinement - Skeleton Loaders",
 		intro:
-			"Eliminated layout shifts and optimized perceived performance by implementing a standardized 'Skeleton Loader' pattern across all data-intensive analytics components.",
+			"Improved perceived performance by standardizing skeleton loading states across data-heavy views.",
 		timeline: [
 			{
 				date: "2026-02-08",
 				title: "Skeleton Loaders Implementation",
 				description:
-					"Implemented a 'Skeleton Loader' pattern for the Analytics to eliminate layout shift and ensure a stable UI during asynchronous data fetching.",
+					"Implemented skeleton loaders for analytics surfaces to reserve layout space during asynchronous data fetching and reduce visual jumps.",
 			},
 		],
 	},
 	{
 		title: "Scale & Asynchronous Architecture",
 		intro:
-			"Architected a decoupled, event-driven pipeline using Azure Queue Storage to support high-velocity bulk processing. This scalable model ensures 100% UI responsiveness while maintaining intelligent validation and system resilience.",
+			"Moved batch generation into a decoupled, event-driven pipeline with Azure Queue Storage and MongoDB-backed job state. The UI can submit work, poll progress, and remain responsive while the worker processes images.",
 		timeline: [
 			{
 				date: "2026-02-26",
 				title: "ADR 006: Asynchronous Job Queue Architecture",
 				description:
-					"Proposed the decision to transition from synchronous HTTP processing to a stateless Background Worker model. This architecture prioritizes UI responsiveness during batch operations by utilizing MongoDB for job state and Azure Timer Triggers for distributed processing.",
+					"Documented the transition from synchronous HTTP batch processing to an asynchronous job model. The accepted design uses MongoDB for job state, HTTP 202 responses for submission, and Azure Queue Storage for background processing.",
 				adrPath: "006-batch-image-generation-architecture",
 			},
 			{
 				date: "2026-02-28",
 				title: "Asynchronous Bulk Generation",
 				description:
-					"Engineered a decoupled, event-driven pipeline for high-velocity bulk processing, ensuring 100% UI responsiveness during heavy workloads. Leveraged Azure Queue Storage for instantaneous distributed generation and integrated intelligent 'pre-flight' validation to maximize system resilience and user efficiency.",
+					"Implemented queued bulk generation with pre-flight validation, job status polling, and fault isolation through settled per-image processing. This keeps long-running work out of the request/response path.",
 				adrPath: "006-batch-image-generation-architecture",
 			},
 		],
 	},
 	{
-		title: "Infrastructure as Code",
+		title: "Infrastructure, Reliability & Documentation",
 		intro:
-			"Standardized infrastructure management using Terraform (OpenTofu) to achieve full environmental sovereignty. Transitioned to a codified architecture to ensure deterministic deployments and eliminate configuration drift.",
+			"Codified the Azure platform with OpenTofu, documented operational lessons as RCAs, and strengthened batch reliability with retry-aware processing.",
 		timeline: [
 			{
 				date: "2026-04-08",
 				title: "ADR 007: Infrastructure as Code for Azure Cloud Services",
 				description:
-					"Architected a codified Azure platform using OpenTofu, replacing manual cloud configuration with a deterministic Infrastructure-as-Code (IaC) model for Azure Functions, Azure Web App, storage, Application Insights, and deployment configuration.",
+					"Migrated Azure resource management into OpenTofu modules for Azure Functions, Azure Web App hosting, storage, Application Insights, and runtime configuration.",
 				adrPath: "007-infrastructure-as-code-azure-cloud-services",
+			},
+			{
+				date: "2026-04-08",
+				title: "Flex Consumption Deployment Hardening",
+				description:
+					"Resolved deployment configuration gaps from the Azure Functions Flex Consumption migration, including CI authentication for OpenTofu, package-based API execution, and removal of unsupported runtime settings.",
+				lessonLearned:
+					"Hosting-plan migrations need configuration review, not just resource translation. Settings that worked in one Azure Functions model can be invalid in another.",
+			},
+			{
+				date: "2026-04-11",
+				title: "Architecture and Incident Documentation",
+				description:
+					"Added architecture, operations, decision, and incident documentation so production lessons are visible alongside implementation details.",
+				lessonLearned:
+					"RCAs turn one-off fixes into reusable engineering knowledge by capturing impact, root cause, resolution, and prevention steps.",
+			},
+			{
+				date: "2026-04-21",
+				title: "Retry-Aware Batch Processing",
+				description:
+					"Strengthened batch job resilience with atomic worker claiming, stale-job recovery, bounded job attempts, and per-image retries for transient rendering failures.",
+				lessonLearned:
+					"Queue-based systems need explicit retry and recovery semantics. Without bounded attempts and stale lock handling, transient failures can become stuck jobs or duplicate work.",
 			},
 		],
 	},

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,14 +8,9 @@ import MainLayout from "@/components/layout/MainLayout";
 export default function LandingPage() {
 	return (
 		<MainLayout>
-			<div className="flex flex-col gap-16 max-w-3xl mx-auto">
-				{/* Hero Section */}
+			<div className="flex flex-col gap-14 max-w-4xl mx-auto">
 				<HeroSection />
-
-				{/* Origin Story */}
 				<OriginStory />
-
-				{/* Principles */}
 				<Principles />
 			</div>
 		</MainLayout>

--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -1,44 +1,53 @@
 import Link from "next/link";
-import { Button, SectionTitle } from "@/components/ui";
+import { SectionTitle } from "@/components/ui";
 
 export function HeroSection() {
-	const ctaButtons = [
-		{ href: "/generate", label: "Try the Generator", external: false },
-		{ href: "/analytics", label: "See the Analytics", external: false },
-		{ href: "/evolution", label: "See How It Evolved", external: false },
+	const actions = [
+		{ href: "/generate", label: "Start generating", external: false },
 		{
 			href: "https://github.com/victoriacheng15/cover-craft",
-			label: "View Source Code",
+			label: "View source",
 			external: true,
 		},
+		{ href: "/generate/batch", label: "Bulk generation", external: false },
+		{ href: "/analytics", label: "Analytics", external: false },
+		{ href: "/evolution", label: "Evolution", external: false },
 	];
+	const actionClass =
+		"flex min-h-14 w-full items-center justify-center rounded-lg border border-emerald-600 bg-white/75 px-5 py-3 text-base font-bold text-gray-900 shadow-sm transition-colors hover:bg-emerald-300 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-offset-2";
 
 	return (
-		<section className="text-center flex flex-col items-center gap-10 py-10">
-			<div className="flex flex-col items-center gap-4">
-				<SectionTitle size="xl" as="h2">
-					Generate Clean, Accessibility-First Covers. Zero Tracking. Zero
-					Friction.
+		<section className="flex flex-col items-center gap-8 py-10 text-center">
+			<div className="flex flex-col items-center gap-5 max-w-3xl">
+				<SectionTitle size="xl" as="h2" className="text-4xl md:text-5xl">
+					Generate clean, readable cover images without design-tool setup.
 				</SectionTitle>
+				<p className="text-lg md:text-xl text-gray-700 leading-relaxed">
+					Cover Craft creates PNG covers from simple text, color, and layout
+					controls. It includes accessibility checks, fast single-image
+					generation, and queued batch processing for repeat work.
+				</p>
 			</div>
-			<div className="grid grid-cols-1 sm:grid-cols-2 gap-4 w-full max-w-2xl">
-				{ctaButtons.map(({ href, label, external }) => (
-					<Link
-						key={href}
-						href={href}
-						target={external ? "_blank" : undefined}
-						rel={external ? "noopener noreferrer" : undefined}
-						className="w-full"
-					>
-						<Button
-							variant="secondary"
-							className="w-full px-6 py-6 text-lg font-semibold"
+
+			<nav aria-label="Landing page actions" className="w-full max-w-2xl">
+				<ul className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+					{actions.map(({ href, label, external }, index) => (
+						<li
+							key={href}
+							className={index === actions.length - 1 ? "sm:col-span-2" : ""}
 						>
-							{label}
-						</Button>
-					</Link>
-				))}
-			</div>
+							<Link
+								href={href}
+								target={external ? "_blank" : undefined}
+								rel={external ? "noopener noreferrer" : undefined}
+								className={actionClass}
+							>
+								{label}
+							</Link>
+						</li>
+					))}
+				</ul>
+			</nav>
 		</section>
 	);
 }

--- a/frontend/src/components/landing/OriginStory.tsx
+++ b/frontend/src/components/landing/OriginStory.tsx
@@ -2,20 +2,21 @@ import { SectionTitle } from "@/components/ui";
 
 export function OriginStory() {
 	const paragraphs = [
-		"I used to generate LinkedIn cover images with a local Python script. It was simple, but I had to wrestle with virtual environments every time I needed a new one. I just wanted a reliable, no-setup way to make clean, readable covers.",
-		"So I rebuilt it as a lightweight web app using Azure Functions and Next.js. With no login and no dependencies, you can just generate and download.",
-		"Only after it was working did I add basic analytics. It was initially just for curiosity, but it soon became a way to learn from real usage: which settings failed, which were popular, and what to refine next.",
-		"That turned Cover Craft from a simple image generator into a quiet lesson in observable, privacy-first software.",
+		"Cover Craft started as a local Python script for making LinkedIn cover images. It solved the immediate problem, but every new run still depended on local setup, virtual environments, and machine-specific behavior.",
+		"The web version keeps the useful part and removes the setup cost: choose the content, adjust the visual treatment, generate a PNG, and download it. No account is required.",
+		"As the project grew, it became a full-stack sandbox for production habits: shared validation, serverless rendering, queue-backed batch jobs, infrastructure as code, and anonymized analytics.",
 	];
 
 	return (
-		<section className="text-gray-600 flex flex-col gap-4">
+		<section className="flex flex-col gap-4">
 			<SectionTitle size="lg">Why I Built This</SectionTitle>
-			{paragraphs.map((text) => (
-				<p key={text.slice(0, 20)} className="text-lg tracking-wide">
-					{text}
-				</p>
-			))}
+			<div className="text-gray-700 flex flex-col gap-4">
+				{paragraphs.map((text) => (
+					<p key={text.slice(0, 24)} className="text-lg leading-relaxed">
+						{text}
+					</p>
+				))}
+			</div>
 		</section>
 	);
 }

--- a/frontend/src/components/landing/Principles.tsx
+++ b/frontend/src/components/landing/Principles.tsx
@@ -3,41 +3,41 @@ import { Card, SectionTitle } from "@/components/ui";
 export function Principles() {
 	const engineeringPrinciples = [
 		{
-			icon: "🎨",
-			title: "Shift-Left Accessibility",
+			label: "A11y",
+			title: "Accessible by Default",
 			description:
-				"Automated WCAG AA contrast validation is baked into the generation pipeline, preventing inaccessible output by design.",
+				"Contrast feedback and shared validation make readability visible while the image is being configured, not after export.",
 		},
 		{
-			icon: "🔒",
-			title: "Privacy by Design",
+			label: "Privacy",
+			title: "No Account Required",
 			description:
-				"A zero-data architecture with no cookies, no tracking, and no persistence, ensuring complete user anonymity.",
+				"No account is required, and analytics are anonymized product and system metrics rather than personal profiles.",
 		},
 		{
-			icon: "🖼️",
-			title: "Stateless Reliability",
+			label: "Render",
+			title: "Serverless Rendering",
 			description:
-				"Server-side rendering via Azure Functions ensures consistent visual fidelity and cross-platform rendering accuracy.",
+				"Azure Functions handles image generation so browser differences do not define the final downloaded PNG.",
 		},
 		{
-			icon: "📊",
-			title: "Privacy-First Observability",
+			label: "Ops",
+			title: "Built for Learning",
 			description:
-				"Structured, anonymized telemetry provides system insights and performance monitoring without compromising user privacy.",
+				"Telemetry, RCAs, and infrastructure code make the project useful as both a product and a mentorship sandbox.",
 		},
 	];
 
 	return (
-		<section>
+		<section className="flex flex-col gap-6">
 			<SectionTitle size="lg" className="mb-6">
-				🧭 Engineering Principles
+				What This Project Shows
 			</SectionTitle>
 			<div className="grid md:grid-cols-2 gap-6">
 				{engineeringPrinciples.map((principle) => (
-					<Card key={principle.title} className="flex flex-col gap-2 p-6">
-						<span className="text-3xl" aria-hidden="true">
-							{principle.icon}
+					<Card key={principle.title} className="flex flex-col gap-3 p-6">
+						<span className="w-fit rounded-md bg-emerald-100 px-2.5 py-1 text-xs font-bold uppercase tracking-wide text-emerald-900">
+							{principle.label}
 						</span>
 						<SectionTitle as="h3" size="md">
 							{principle.title}


### PR DESCRIPTION
### Summary
This change refines the project-facing documentation and frontend narrative so Cover Craft reads less like a tool list and more like an evidence-backed engineering project. The README now points readers to concrete case studies with RCA and ADR links, while the landing and evolution pages use clearer, more accurate language about the platform's growth.

### List of Changes
- Reworked the landing page copy and calls to action to make the product entry points clearer.
- Updated the evolution timeline and README case studies to connect project milestones with supporting RCA and ADR evidence.

### Verification
- [x] `npm run lint:frontend`
- [x] `npm run test:frontend`

