### PR TITLE
refactor(frontend): align landingConfig with updated generic yaml schema

### DIFF
--- a/frontend/src/components/ShowcaseSections.tsx
+++ b/frontend/src/components/ShowcaseSections.tsx
@@ -59,11 +59,11 @@ export function ArchitectureBlueprint() {
 				as="h3"
 				className="text-2xl font-bold tracking-tight"
 			>
-				Architecture Blueprint
+				Architecture
 			</SectionTitle>
 			<div className="relative rounded-xl border border-slate-800 bg-slate-950 p-6 shadow-lg overflow-x-auto">
 				<pre className="font-mono text-xs md:text-sm text-slate-100 leading-relaxed select-all">
-					{landingConfig.reach.architecture_blueprint.diagram_ascii}
+					{landingConfig.architecture.diagram_ascii}
 				</pre>
 			</div>
 		</section>
@@ -81,39 +81,19 @@ export function CoreComponents() {
 				Core Components & Logic
 			</SectionTitle>
 			<ul className="space-y-4 text-gray-700 bg-white p-6 rounded-xl border border-emerald-200 shadow-sm list-none">
-				<li className="flex items-start gap-3">
-					<span className="shrink-0 w-2 h-2 rounded-full bg-emerald-500 mt-2" />
-					<div>
-						<strong className="text-gray-900 block text-base font-bold">
-							Canvas Rendering Engine
-						</strong>
-						<p className="text-sm text-gray-600 leading-relaxed mt-0.5">
-							{landingConfig.tech.core_component_1.description}
-						</p>
-					</div>
-				</li>
-				<li className="flex items-start gap-3">
-					<span className="shrink-0 w-2 h-2 rounded-full bg-emerald-500 mt-2" />
-					<div>
-						<strong className="text-gray-900 block text-base font-bold">
-							Queue-backed Batch Processor
-						</strong>
-						<p className="text-sm text-gray-600 leading-relaxed mt-0.5">
-							{landingConfig.tech.core_component_2.description}
-						</p>
-					</div>
-				</li>
-				<li className="flex items-start gap-3">
-					<span className="shrink-0 w-2 h-2 rounded-full bg-emerald-500 mt-2" />
-					<div>
-						<strong className="text-gray-900 block text-base font-bold">
-							Accessible Client Portal
-						</strong>
-						<p className="text-sm text-gray-600 leading-relaxed mt-0.5">
-							{landingConfig.tech.core_component_3.description}
-						</p>
-					</div>
-				</li>
+				{landingConfig.tech.map((component) => (
+					<li key={component.title} className="flex items-start gap-3">
+						<span className="shrink-0 w-2 h-2 rounded-full bg-emerald-500 mt-2" />
+						<div>
+							<strong className="text-gray-900 block text-base font-bold">
+								{component.title}
+							</strong>
+							<p className="text-sm text-gray-600 leading-relaxed mt-0.5">
+								{component.description}
+							</p>
+						</div>
+					</li>
+				))}
 			</ul>
 		</section>
 	);
@@ -130,39 +110,19 @@ export function ValidationResiliency() {
 				Validation & Resiliency Testing
 			</SectionTitle>
 			<ul className="space-y-4 text-gray-700 bg-white p-6 rounded-xl border border-emerald-200 shadow-sm list-none">
-				<li className="flex items-start gap-3">
-					<span className="shrink-0 w-2 h-2 rounded-full bg-blue-500 mt-2" />
-					<div>
-						<strong className="text-gray-900 block text-base font-bold">
-							Reproducibility
-						</strong>
-						<p className="text-sm text-gray-600 leading-relaxed mt-0.5">
-							{landingConfig.proof.reproducibility.description}
-						</p>
-					</div>
-				</li>
-				<li className="flex items-start gap-3">
-					<span className="shrink-0 w-2 h-2 rounded-full bg-blue-500 mt-2" />
-					<div>
-						<strong className="text-gray-900 block text-base font-bold">
-							Automated Verification
-						</strong>
-						<p className="text-sm text-gray-600 leading-relaxed mt-0.5">
-							{landingConfig.proof.automated_verification.description}
-						</p>
-					</div>
-				</li>
-				<li className="flex items-start gap-3">
-					<span className="shrink-0 w-2 h-2 rounded-full bg-blue-500 mt-2" />
-					<div>
-						<strong className="text-gray-900 block text-base font-bold">
-							Telemetry Pipeline
-						</strong>
-						<p className="text-sm text-gray-600 leading-relaxed mt-0.5">
-							{landingConfig.proof.telemetry_pipeline.description}
-						</p>
-					</div>
-				</li>
+				{landingConfig.proof.map((item) => (
+					<li key={item.title} className="flex items-start gap-3">
+						<span className="shrink-0 w-2 h-2 rounded-full bg-blue-500 mt-2" />
+						<div>
+							<strong className="text-gray-900 block text-base font-bold">
+								{item.title}
+							</strong>
+							<p className="text-sm text-gray-600 leading-relaxed mt-0.5">
+								{item.description}
+							</p>
+						</div>
+					</li>
+				))}
 			</ul>
 		</section>
 	);
@@ -179,7 +139,7 @@ export function DesignTradeoffs() {
 				Design Trade-offs & Verification Logs
 			</SectionTitle>
 			<div className="flex flex-col gap-8">
-				{/* #### Humble Pivots */}
+				{/* Humble Pivots */}
 				<div className="flex flex-col gap-4">
 					<SectionTitle size="md" as="h4" className="text-xl font-bold">
 						Humble Pivots
@@ -205,7 +165,7 @@ export function DesignTradeoffs() {
 					</div>
 				</div>
 
-				{/* #### Objective Clarity */}
+				{/* Objective Clarity */}
 				<div className="flex flex-col gap-4">
 					<SectionTitle size="md" as="h4" className="text-xl font-bold">
 						Objective Clarity
@@ -217,7 +177,7 @@ export function DesignTradeoffs() {
 					</div>
 				</div>
 
-				{/* #### Verifiable Outputs */}
+				{/* Verifiable Outputs */}
 				<div className="flex flex-col gap-4">
 					<SectionTitle size="md" as="h4" className="text-xl font-bold">
 						Verifiable Outputs

--- a/frontend/src/lib/landingConfig.ts
+++ b/frontend/src/lib/landingConfig.ts
@@ -1,17 +1,11 @@
 export interface CoreComponent {
+	title: string;
 	description: string;
 }
 
-export interface ProofSection {
-	reproducibility: {
-		description: string;
-	};
-	automated_verification: {
-		description: string;
-	};
-	telemetry_pipeline: {
-		description: string;
-	};
+export interface ProofItem {
+	title: string;
+	description: string;
 }
 
 export interface Pivot {
@@ -37,16 +31,12 @@ export interface LandingConfig {
 		persistence_strategy: string;
 		observability: string;
 	};
-	tech: {
-		core_component_1: CoreComponent;
-		core_component_2: CoreComponent;
-		core_component_3: CoreComponent;
+	architecture: {
+		diagram_ascii: string;
 	};
-	proof: ProofSection;
+	tech: CoreComponent[];
+	proof: ProofItem[];
 	reach: {
-		architecture_blueprint: {
-			diagram_ascii: string;
-		};
 		humble_pivots: Pivot[];
 		objective_clarity: {
 			description: string;
@@ -79,37 +69,8 @@ export const landingConfig: LandingConfig = {
 		observability:
 			"Structured JSON logger, custom metrics, and telemetry dashboarding",
 	},
-	tech: {
-		core_component_1: {
-			description:
-				"Canvas rendering engine running inside Azure Functions to dynamically compile text, custom typography, and layout styles into consistent PNG images.",
-		},
-		core_component_2: {
-			description:
-				"Queue-backed batch processor with a retry-aware serverless worker that coordinates bulk generation requests asynchronously via Azure Queue Storage and tracks progress in MongoDB.",
-		},
-		core_component_3: {
-			description:
-				"Accessible client portal with real-time WCAG AA contrast validation, color palette selection, and unified inputs shared programmatically with the validation engine.",
-		},
-	},
-	proof: {
-		reproducibility: {
-			description:
-				"Declarative infrastructure provisioning with OpenTofu (Terraform-compatible) and automated GitHub Actions CI/CD workflows for consistent serverless deployment.",
-		},
-		automated_verification: {
-			description:
-				"Comprehensive Vitest test suite executing client component validation, shared rules, and API handlers under automated test runs.",
-		},
-		telemetry_pipeline: {
-			description:
-				"Structured application monitoring logs and MongoDB query tracking to observe backend execution bottlenecks and queue latencies.",
-		},
-	},
-	reach: {
-		architecture_blueprint: {
-			diagram_ascii: `┌──────────────────────────────────────────────────────────────────┐
+	architecture: {
+		diagram_ascii: `┌──────────────────────────────────────────────────────────────────┐
 │                        Next.js Client UI                         │
 └──────────────────────────────────────────────────────────────────┘
                                  │
@@ -149,7 +110,42 @@ export const landingConfig: LandingConfig = {
                         │             MongoDB              │
                         │           (Job Status)           │
                         └──────────────────────────────────┘`,
+	},
+	tech: [
+		{
+			title: "Canvas Rendering Engine",
+			description:
+				"Canvas rendering engine running inside Azure Functions to dynamically compile text, custom typography, and layout styles into consistent PNG images.",
 		},
+		{
+			title: "Queue-backed Batch Processor",
+			description:
+				"Queue-backed batch processor with a retry-aware serverless worker that coordinates bulk generation requests asynchronously via Azure Queue Storage and tracks progress in MongoDB.",
+		},
+		{
+			title: "Accessible Client Portal",
+			description:
+				"Accessible client portal with real-time WCAG AA contrast validation, color palette selection, and unified inputs shared programmatically with the validation engine.",
+		},
+	],
+	proof: [
+		{
+			title: "Reproducibility",
+			description:
+				"Declarative infrastructure provisioning with OpenTofu (Terraform-compatible) and automated GitHub Actions CI/CD workflows for consistent serverless deployment.",
+		},
+		{
+			title: "Automated Verification",
+			description:
+				"Comprehensive Vitest test suite executing client component validation, shared rules, and API handlers under automated test runs.",
+		},
+		{
+			title: "Telemetry Pipeline",
+			description:
+				"Structured application monitoring logs and MongoDB query tracking to observe backend execution bottlenecks and queue latencies.",
+		},
+	],
+	reach: {
 		humble_pivots: [
 			{
 				title: "Azure Functions Monorepo Packaging & Deployment",


### PR DESCRIPTION
### Summary
Refactored the landing configuration schema and interface types to align with the updated generic `landing.yaml` design specification. Root level interfaces and structural definitions were restructured to represent logical components, testing details, and diagrams as arrays and root-level fields rather than statically nested objects.

### List of Changes
- Refactored `LandingConfig` typescript interfaces and variable exports to match standard portfolio schema structures.
- Updated `ShowcaseSections.tsx` to dynamically map and iterate over the restructured component and verification properties.

### Verification
- [x] `npm run lint`
- [x] `npm run test:frontend`

