### PR TITLE
docs(readme): standardize architecture and pipeline diagrams to ASCII

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,41 +18,100 @@ It supports fast single-image generation and queued batch processing, with share
 
 ---
 
-## Architecture
+## Architecture & Infrastructure
 
-The platform has two generation paths:
+### Infrastructure & Deployment Pipeline
+
+The platform's cloud infrastructure is declared using OpenTofu (Terraform-compatible) and deployed via GitHub Actions, with remote state tracked in Azure Blob Storage:
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│                     Git Push / Merge to main                     │
+└──────────────────────────────────────────────────────────────────┘
+                                 │
+                                 ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                  GitHub Actions Runner (CI/CD)                   │
+└──────────────────────────────────────────────────────────────────┘
+                                 │
+                                 │ 1. Azure Login (Service Principal)
+                                 │ 2. Sets up OpenTofu (v1.6.0)
+      ┌────────────────────┐     │ 3. Runs 'tofu init & apply'
+      │ Azure Blob Storage │ <-> │
+      │     (tfstate)      │     │
+      └────────────────────┘     ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                 OpenTofu Infrastructure Apply                    │
+│    (Provision storage, App Insights, Function App, App Service)  │
+└──────────────────────────────────────────────────────────────────┘
+               │                                   │
+               │ Build & Package                   │ Build & Package
+               ▼                                   ▼
+┌──────────────────────────────┐    ┌──────────────────────────────┐
+│   Create api-deploy.zip      │    │ Create frontend-deploy.zip   │
+│   (Bundles shared package)   │    │ (Next.js Standalone build)   │
+└──────────────────────────────┘    └──────────────────────────────┘
+               │                                   │
+               │ Zip Deploy                        │ Zip Deploy
+               │ (config-zip)                      │ (config-zip)
+               ▼                                   ▼
+┌──────────────────────────────┐    ┌──────────────────────────────┐
+│        Azure Function        │    │     Azure App Service UI     │
+│       ("cover-craft")        │    │      ("cover-craft-ui")      │
+└──────────────────────────────┘    └──────────────────────────────┘
+```
+
+### Application Request Flow
+
+The platform has two runtime generation paths:
 
 | Path | Use case | Flow |
 | :--- | :--- | :--- |
 | Single image | Fast interactive generation | User request -> Azure Function -> Canvas renderer -> image response |
 | Batch images | Larger workloads | User request -> HTTP 202 -> Azure Queue Storage -> retry-aware worker -> MongoDB job status |
 
-```mermaid
-graph TD
-    User([User])
-    UI[React UI]
-    API[Azure Functions API]
-    Single[Single Image Function]
-    Batch[Batch Producer Function]
-    Status[Job Status Function]
-    Queue[Azure Queue Storage]
-    Worker[Queue Worker Function]
-    Render[Canvas Renderer]
-    DB[(MongoDB Job State)]
-
-    User --> UI
-    UI --> API
-    API --> Single
-    Single --> Render
-    Render --> UI
-    API --> Batch
-    API --> Status
-    Batch --> Queue
-    Batch --> DB
-    Status --> DB
-    Queue --> Worker
-    Worker --> Render
-    Worker --> DB
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│                        Next.js Client UI                         │
+└──────────────────────────────────────────────────────────────────┘
+                                 │
+                                 │ POST /api/generateImage (Single)
+                                 │ POST /api/generateImages (Batch)
+                                 │ GET /api/jobStatus (Poll Status)
+                                 ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                        Next.js BFF Server                        │
+└──────────────────────────────────────────────────────────────────┘
+         │                       │                       │
+         │ /generateImage        │ /generateImages       │ /getJobStatus
+         ▼                       ▼                       ▼
+┌──────────────────┐    ┌──────────────────┐    ┌──────────────────┐
+│  Azure Function  │    │  Azure Function  │    │  Azure Function  │
+│  (SingleRender)  │    │ (QueueProducer)  │    │  (GetJobStatus)  │
+└──────────────────┘    └──────────────────┘    └──────────────────┘
+         │                       │                       │
+         │ Uses                  │ Enqueues              │ Reads
+         ▼                       ▼                       │ Status
+         │                       │                       │
+┌──────────────────┐    ┌──────────────────┐             │
+│  Canvas Library  │    │   Azure Queue    │             │
+└──────────────────┘    │     Storage      │             │
+         ▲              └──────────────────┘             │
+         │                       │                       │
+         │ Uses                  │ Triggers              │
+         │                       ▼                       │
+         │              ┌──────────────────┐             │
+         │              │  Azure Function  │             │
+         │              │  (QueueWorker)   │             │
+         │              └──────────────────┘             │
+         │                       │                       │
+         └───────────────────────┤                       │
+                                 │ Updates               │
+                                 ▼                       ▼
+                        ┌──────────────────────────────────┐
+                        │             MongoDB              │
+                        │           (Job Status)           │
+                        └──────────────────────────────────┘
 ```
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Welcome to the **Cover Craft** technical documentation. This directory contains 
 ## ⚙️ Operations & DevOps
 
 - [**Operations & CI/CD**](./operations.md)
-  - GitHub Actions workflows, deployment strategies (Vercel/Azure), and secrets management.
+  - GitHub Actions workflows, deployment strategies (Azure Web App/Functions), and secrets management.
 
 ## 🧠 Knowledge Base
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -11,15 +11,46 @@ This directory documents the main system architecture for Cover Craft across the
 
 Cover Craft is split into a Next.js frontend and an Azure Functions backend. Shared validation rules and types live in `@cover-craft/shared`, while Azure cloud resources are managed through OpenTofu.
 
-```mermaid
-graph LR
-    Browser[Browser] --> Frontend[Next.js Frontend]
-    Frontend --> BFF[Next.js API Routes]
-    BFF --> API[Azure Functions API]
-    API --> Render[Canvas Rendering Engine]
-    API --> Queue[Azure Queue Storage]
-    API --> Mongo[(MongoDB)]
-    Queue --> Worker[Batch Worker]
-    Worker --> Render
-    Worker --> Mongo
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│                        Next.js Client UI                         │
+└──────────────────────────────────────────────────────────────────┘
+                                 │
+                                 │ POST /api/generateImage (Single)
+                                 │ POST /api/generateImages (Batch)
+                                 │ GET /api/jobStatus (Poll Status)
+                                 ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                        Next.js BFF Server                        │
+└──────────────────────────────────────────────────────────────────┘
+         │                       │                       │
+         │ /generateImage        │ /generateImages       │ /getJobStatus
+         ▼                       ▼                       ▼
+┌──────────────────┐    ┌──────────────────┐    ┌──────────────────┐
+│  Azure Function  │    │  Azure Function  │    │  Azure Function  │
+│  (SingleRender)  │    │ (QueueProducer)  │    │  (GetJobStatus)  │
+└──────────────────┘    └──────────────────┘    └──────────────────┘
+         │                       │                       │
+         │ Uses                  │ Enqueues              │ Reads
+         ▼                       ▼                       │ Status
+         │                       │                       │
+┌──────────────────┐    ┌──────────────────┐             │
+│  Canvas Library  │    │   Azure Queue    │             │
+└──────────────────┘    │     Storage      │             │
+         ▲              └──────────────────┘             │
+         │                       │                       │
+         │ Uses                  │ Triggers              │
+         │                       ▼                       │
+         │              ┌──────────────────┐             │
+         │              │  Azure Function  │             │
+         │              │  (QueueWorker)   │             │
+         │              └──────────────────┘             │
+         │                       │                       │
+         └───────────────────────┤                       │
+                                 │ Updates               │
+                                 ▼                       ▼
+                        ┌──────────────────────────────────┐
+                        │             MongoDB              │
+                        │           (Job Status)           │
+                        └──────────────────────────────────┘
 ```

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -17,44 +17,44 @@ The backend is a serverless API built on Azure Functions (v4, Node.js 22), respo
 
 The platform implements two distinct execution patterns optimized for different workloads:
 
-```mermaid
-graph TD
-    Client[Client Browser]
-    subgraph Azure["Azure Function App"]
-        Gateway[API Gateway / Router]
-        
-        subgraph SyncPath["Synchronous Path (Single)"]
-            Single["POST /generateImage<br/>(Immediate Render)"]
-        end
-        
-        subgraph AsyncPath["Asynchronous Path (Bulk)"]
-            Bulk["POST /generateImages<br/>(Queue Job)"]
-            Status["GET /jobStatus/{id}<br/>(Poll Progress)"]
-            Worker["Timer Trigger: processJobs<br/>(Background Worker)"]
-        end
-        
-        Render[Canvas Rendering Engine]
-        Queue[Azure Queue Storage]
-    end
-
-    subgraph Data["Data Layer"]
-        Mongo[(MongoDB)]
-    end
-
-    Client --> Gateway
-    Gateway --> Single
-    Gateway --> Bulk
-    Gateway --> Status
-    
-    Single --> Render
-    Single --> Mongo
-    
-    Bulk --> Queue
-    Bulk --> Mongo
-    
-    Queue --> Worker
-    Worker --> Render
-    Worker --> Mongo
+```text
+                    ┌────────────────────────┐
+                    │     Client Browser     │
+                    └────────────────────────┘
+                                 │
+                                 ▼
+                    ┌────────────────────────┐
+                    │  API Gateway / Router  │
+                    └────────────────────────┘
+         ┌───────────────────────┼───────────────────────┐
+         │ /generateImage        │ /generateImages       │ /jobStatus
+         ▼                       ▼                       ▼
+┌──────────────────┐    ┌──────────────────┐    ┌──────────────────┐
+│   Single Image   │    │  Bulk Generator  │    │    Job Status    │
+│ (Immediate Sync) │    │ (Asynchronous)   │    │ (Polling Check)  │
+└──────────────────┘    └──────────────────┘    └──────────────────┘
+         │                       │                       │
+         │ Uses                  │ Enqueues              │ Reads
+         ▼                       ▼                       │ Status
+┌──────────────────┐    ┌──────────────────┐             │
+│ Canvas Rendering │    │   Azure Queue    │             │
+│  Engine (PNG)    │    │     Storage      │             │
+└──────────────────┘    └──────────────────┘             │
+         ▲                       │                       │
+         │                       │ Triggers              │
+         │                       ▼                       │
+         │              ┌──────────────────┐             │
+         │              │ Background Job   │             │
+         │              │ Worker (Process) │             │
+         │              └──────────────────┘             │
+         │                       │                       │
+         └───────────────────────┼───────────────────────┘
+                                 │ Updates / Reads
+                                 ▼
+                        ┌──────────────────┐
+                        │     MongoDB      │
+                        │   (Job State)    │
+                        └──────────────────┘
 ```
 
 ## Functions

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -16,27 +16,24 @@ The frontend is a **Next.js (App Router)** application that provides a real-time
 
 The frontend orchestrates two distinct workflows: direct rendering for previews and polling-based retrieval for batch jobs.
 
-```mermaid
-graph LR
-    Client[Browser] --> Proxy[Next.js API Routes]
-    
-    subgraph ProxyLayer["Proxy Layer (BFF)"]
-        Proxy
-    end
-    
-    subgraph Backend["Azure Functions"]
-        Sync[generateImage]
-        Async[generateImages]
-        Status[jobStatus]
-    end
-
-    Proxy --> Sync
-    Proxy --> Async
-    Proxy --> Status
-    
-    Client -->|1. Submit Batch| Async
-    Client -->|2. Poll Status| Status
-    Client -->|3. Preview| Sync
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│                         Client Browser                           │
+└──────────────────────────────────────────────────────────────────┘
+         │                      │                      │
+         │ 1. Preview           │ 2. Submit Batch      │ 3. Status
+         ▼                      ▼                      ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                   Next.js Proxy Layer (BFF)                      │
+│            (Secures API keys and prevents CORS issues)           │
+└──────────────────────────────────────────────────────────────────┘
+         │                      │                      │
+         │ /generateImage       │ /generateImages      │ /jobStatus
+         ▼                      ▼                      ▼
+┌──────────────────┐   ┌──────────────────┐   ┌──────────────────┐
+│  Azure Function  │   │  Azure Function  │   │  Azure Function  │
+│  (SingleRender)  │   │ (QueueProducer)  │   │  (GetJobStatus)  │
+└──────────────────┘   └──────────────────┘   └──────────────────┘
 ```
 
 ## Architectural Patterns

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -9,8 +9,7 @@ We use path-based triggering to ensure pipelines only run when relevant files ar
 | Workflow | File | Trigger | Purpose |
 | :--- | :--- | :--- | :--- |
 | **Infrastructure & Code Deployment** | `infra-deploy.yml` | Push to `main` when `tofu/`, app workspaces, or root package files change; manual dispatch | Applies OpenTofu, then zip-deploys the Azure Functions API and Next.js frontend to Azure. |
-| **CI - Lint & Test** | `ci.yml` | PR or push to `main` when `api/`, `frontend/`, or `shared/` changes; manual dispatch | Runs project linting, then selectively runs API and frontend tests based on changed paths. |
-| **Markdown Linter** | `markdownlint.yml` | PR to `main` when Markdown changes; manual dispatch | Validates Markdown formatting using a custom action. |
+| **CI - Lint & Test** | `ci.yml` | PR or push to `main` when code or documentation changes; manual dispatch | Runs Biome code checks, Markdown linting, and selectively executes backend and frontend test suites based on modified paths. |
 
 ## Deployment Configuration
 
@@ -21,6 +20,7 @@ Managed via OpenTofu (IaC) and orchestrated in Canada Central.
 | Setting | Value | Description |
 | :--- | :--- | :--- |
 | **Infrastructure Engine** | `OpenTofu` | Codified resource management via `.tf` files. |
+| **Tofu State Backend** | `Azure Blob Storage (tfstate)` | Remote state management to prevent configuration drift. |
 | **API Plan** | `Flex Consumption (FC1)` | High-performance serverless Node.js 22 runtime. |
 | **Frontend Plan** | `App Service (F1)` | Zero-cost Linux hosting for the Next.js standalone UI. |
 | **Primary Region** | `Canada Central` | Targeted regional deployment for performance and compliance. |
@@ -47,31 +47,69 @@ Managed via OpenTofu (IaC) and orchestrated in Canada Central.
 
 ### 1. Continuous Integration (PR Validation)
 
-```mermaid
-graph LR
-    Start([PR or Push]) --> Changes[Path Filter]
-    Start --> Lint[Lint]
-    Changes --> TestAPI[Test API when api/shared changed]
-    Changes --> TestFE[Test Frontend when frontend/shared changed]
-    Lint --> TestAPI
-    Lint --> TestFE
-    TestAPI --> End([Ready to Merge])
-    TestFE --> End
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│                    GitHub PR or Push to main                     │
+└──────────────────────────────────────────────────────────────────┘
+                 │                                  │
+                 ▼ (Path Filter)                    ▼
+┌──────────────────────────────┐    ┌──────────────────────────────┐
+│   Verify api/ or shared/     │    │   Run Project-Wide Linting   │
+│   code changes exist         │    │   (Biome & Markdownlint)     │
+└──────────────────────────────┘    └──────────────────────────────┘
+                 │                                  │
+                 ├──────────────────────────────────┤
+                 ▼                                  ▼
+┌──────────────────────────────┐    ┌──────────────────────────────┐
+│       Run API Tests          │    │     Run Frontend Tests       │
+│       (Vitest suite)         │    │       (Vitest suite)         │
+└──────────────────────────────┘    └──────────────────────────────┘
+                 │                                  │
+                 └────────────────┬─────────────────┘
+                                  │
+                                  ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                   PR Verified / Ready to Merge                   │
+└──────────────────────────────────────────────────────────────────┘
 ```
 
 ### 2. Continuous Deployment
 
 The entire platform is orchestrated as a single, cohesive unit on Azure.
 
-```mermaid
-graph TD
-    Main([Merge to Main]) --> Tofu[OpenTofu: Apply Infra]
-    Tofu --> BuildAPI[Build Shared + API]
-    Tofu --> BuildUI[Build Shared + Frontend]
-    BuildAPI --> PackageAPI[Create api-deploy.zip]
-    BuildUI --> PackageUI[Create frontend-deploy.zip]
-    PackageAPI --> DeployAPI[Zip Deploy: Azure Functions]
-    PackageUI --> DeployUI[Zip Deploy: Azure Web App]
-    DeployAPI --> Live((Live App))
-    DeployUI --> Live
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│                     Git Push / Merge to main                     │
+└──────────────────────────────────────────────────────────────────┘
+                                 │
+                                 ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                  GitHub Actions Runner (CI/CD)                   │
+└──────────────────────────────────────────────────────────────────┘
+                                 │
+                                 │ 1. Azure Login (Service Principal)
+                                 │ 2. Sets up OpenTofu (v1.6.0)
+      ┌────────────────────┐     │ 3. Runs 'tofu init & apply'
+      │ Azure Blob Storage │ <-> │
+      │     (tfstate)      │     │
+      └────────────────────┘     ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                 OpenTofu Infrastructure Apply                    │
+│    (Provision storage, App Insights, Function App, App Service)  │
+└──────────────────────────────────────────────────────────────────┘
+               │                                   │
+               │ Build & Package                   │ Build & Package
+               ▼                                   ▼
+┌──────────────────────────────┐    ┌──────────────────────────────┐
+│   Create api-deploy.zip      │    │ Create frontend-deploy.zip   │
+│   (Bundles shared package)   │    │ (Next.js Standalone build)   │
+└──────────────────────────────┘    └──────────────────────────────┘
+               │                                   │
+               │ Zip Deploy                        │ Zip Deploy
+               │ (config-zip)                      │ (config-zip)
+               ▼                                   ▼
+┌──────────────────────────────┐    ┌──────────────────────────────┐
+│        Azure Function        │    │     Azure App Service UI     │
+│       ("cover-craft")        │    │      ("cover-craft-ui")      │
+└──────────────────────────────┘    └──────────────────────────────┘
 ```


### PR DESCRIPTION
### Summary
The repository documentation contained inconsistent diagram formats (mix of Mermaid and ASCII) and obsolete pipeline descriptions. This update standardizes all system architecture and deployment diagrams to ASCII art across the project and documents the consolidated CI workflow and OpenTofu remote state storage in Azure.

### List of Changes
- Convert all system architecture and pipeline diagrams to ASCII format across the main README and the docs directory to establish visual consistency.
- Update the operations documentation to reflect the merging of the Markdown linter workflow into the main CI pipeline.
- Document the OpenTofu remote state tracking in Azure Blob Storage within the Azure platform configuration settings.

### Verification
- [x] Run `npm run lint:md` to verify markdown formatting compliance.

