### PR TITLE
feat(docker): add local development container configuration

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,80 @@
+# ==============================================================================
+# Development Dockerfile (Support Hot-Reloading via volume mounts)
+# ==============================================================================
+# Build command:
+#   podman build -t cover-craft-dev:latest -f Dockerfile.dev .
+#
+# Run command (with volume mount and port mappings):
+#   podman run -d \
+#     -p 3000:3000 \
+#     -p 7071:7071 \
+#     -p 10000:10000 \
+#     -p 10001:10001 \
+#     -p 10002:10002 \
+#     -v .:/app:Z \
+#     --name cover-craft-dev-container \
+#     cover-craft-dev:latest
+# ==============================================================================
+
+FROM node:lts-bookworm-slim
+WORKDIR /app
+
+# Install native dependencies for node-canvas, process management, and utils
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libgif-dev \
+    librsvg2-dev \
+    libcairo2 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libjpeg62-turbo \
+    libgif7 \
+    librsvg2-2 \
+    procps \
+    ca-certificates \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PM2 and Azure Functions Core Tools globally
+RUN npm install -g pm2 azure-functions-core-tools@4
+
+# Copy package descriptors first to build a cache
+COPY package.json package-lock.json ./
+COPY shared/package.json ./shared/
+COPY api/package.json ./api/
+COPY frontend/package.json ./frontend/
+
+# Clean install all dependencies (including devDependencies)
+RUN npm ci
+
+# Copy the rest of the workspace files
+COPY . .
+
+# Expose ports for frontend, api, and azurite
+EXPOSE 3000 7071 10000 10001 10002
+
+# Write startup entrypoint script to handle dynamic node_modules and compilation
+RUN echo '#!/bin/bash\n\
+set -e\n\
+\n\
+# Install dependencies if they are missing from the mounted volume\n\
+if [ ! -d "node_modules" ]; then\n\
+  echo "Missing node_modules in volume. Installing..."\n\
+  npm install\n\
+fi\n\
+\n\
+# Build the shared library initially\n\
+npm run build:shared\n\
+\n\
+# Copy fonts asset for API\n\
+npm run copy:assets --workspace=api\n\
+\n\
+# Start PM2 dev processes\n\
+exec pm2-runtime /app/processes.dev.json' > /usr/local/bin/entrypoint.sh && \
+    chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
 		"build:shared": "npm run build --workspace=@cover-craft/shared",
 		"build:frontend": "npm run build:shared && npm run build --workspace=frontend",
 		"dev:frontend": "npm run dev --workspace=frontend",
-		"start:api": "mkdir -p __azurite_db__ && azurite --silent --location ./__azurite_db__ & npm run build:shared && npm run start --workspace=api"
+		"start:api": "mkdir -p __azurite_db__ && azurite --silent --location ./__azurite_db__ & npm run build:shared && npm run start --workspace=api",
+		"docker:build:dev": "podman build -t cover-craft-dev:latest -f Dockerfile.dev .",
+		"docker:run:dev": "podman run -d -p 3000:3000 -p 7071:7071 -p 10000:10000 -p 10001:10001 -p 10002:10002 -v .:/app:Z --name cover-craft-dev-container cover-craft-dev:latest"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.3",

--- a/processes.dev.json
+++ b/processes.dev.json
@@ -1,0 +1,36 @@
+{
+  "apps": [
+    {
+      "name": "shared-watch",
+      "script": "npx",
+      "args": "tsc -p shared/tsconfig.json -w",
+      "cwd": "/app"
+    },
+    {
+      "name": "api-watch",
+      "script": "npx",
+      "args": "tsc -p api/tsconfig.json -w",
+      "cwd": "/app"
+    },
+    {
+      "name": "api",
+      "script": "func",
+      "args": "start",
+      "cwd": "/app/api",
+      "interpreter": "none"
+    },
+    {
+      "name": "frontend",
+      "script": "npm",
+      "args": "run dev --workspace=frontend",
+      "cwd": "/app"
+    },
+    {
+      "name": "azurite",
+      "script": "/app/node_modules/.bin/azurite",
+      "args": "--silent --location /app/__azurite_db__",
+      "cwd": "/app",
+      "interpreter": "none"
+    }
+  ]
+}


### PR DESCRIPTION
### Summary
Local development of the full-stack monorepo previously required manually launching multiple watchers and service runtimes. This change introduces a development Dockerfile and a PM2 process configuration to orchestrate all workspaces and dependencies in a single container. It also integrates build and run scripts into the root package descriptor to simplify local execution.

### List of Changes
- Add a development container configuration supporting live hot-reloading through volume mounts and compiler watchers.
- Define a process manager config to launch the shared package compiler, API host, Next.js dev server, and database concurrently.
- Introduce container build and run scripts in the root package descriptor to facilitate one-click local orchestration.

### Verification
- [x] Verified that PM2 correctly spawns all five development processes concurrently
- [x] Validate that file edits on the host trigger hot-reloading inside the running container

