### PR TITLE
docs(docker): refine container run options and document cleanup

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,7 +5,7 @@
 #   podman build -t cover-craft-dev:latest -f Dockerfile.dev .
 #
 # Run command (with volume mount and port mappings):
-#   podman run -d \
+#   podman run -d --rm \
 #     -p 3000:3000 \
 #     -p 7071:7071 \
 #     -p 10000:10000 \

--- a/README.md
+++ b/README.md
@@ -151,6 +151,19 @@ Run the API locally:
 npm run start:api
 ```
 
+Alternatively, the entire stack can run inside a single local development container. This configuration orchestrates Next.js, the Azure Functions API, and Azurite with hot-reloading enabled. The root package descriptor provides simple scripts to build and start the environment.
+
+```bash
+# Build the development container
+npm run docker:build:dev
+
+# Start the container with hot-reloading
+npm run docker:run:dev
+
+# Remove the built development image
+npm run docker:clean:dev
+```
+
 Run checks:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
 		"dev:frontend": "npm run dev --workspace=frontend",
 		"start:api": "mkdir -p __azurite_db__ && azurite --silent --location ./__azurite_db__ & npm run build:shared && npm run start --workspace=api",
 		"docker:build:dev": "podman build -t cover-craft-dev:latest -f Dockerfile.dev .",
-		"docker:run:dev": "podman run -d -p 3000:3000 -p 7071:7071 -p 10000:10000 -p 10001:10001 -p 10002:10002 -v .:/app:Z --name cover-craft-dev-container cover-craft-dev:latest"
+		"docker:run:dev": "podman run -d --rm -p 3000:3000 -p 7071:7071 -p 10000:10000 -p 10001:10001 -p 10002:10002 -v .:/app:Z --name cover-craft-dev-container cover-craft-dev:latest",
+		"docker:clean:dev": "podman rmi cover-craft-dev:latest"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.3",


### PR DESCRIPTION
### Summary
The development container setup previously lacked mechanisms for automatic container cleanup and image removal. This change adds the `--rm` flag to the container execution configuration and introduces an image cleanup script in the package descriptor. It also documents the new setup and clean options in the root README for improved developer usability.

### List of Changes
- Integrate automatic container removal with the --rm flag to prevent name conflicts during repeated local runs.
- Define an NPM cleanup script to easily remove the local development image from container storage.
- Update the root README to document the new build, execution, and image cleanup workflows.

### Verification
- [x] Verified that running the container with --rm cleans up resources upon container shutdown
- [x] Tested the clean script to verify successful deletion of the local development image

