### PR TITLE
docs(readme): add docker compatibility command note

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Run the API locally:
 npm run start:api
 ```
 
-Alternatively, the entire stack can run inside a single local development container. This configuration orchestrates Next.js, the Azure Functions API, and Azurite with hot-reloading enabled. The root package descriptor provides simple scripts to build and start the environment.
+Alternatively, the entire stack can run inside a single local development container. This configuration utilizes Podman to orchestrate Next.js, the Azure Functions API, and Azurite with hot-reloading enabled. If using Docker, replace the `podman` command prefix with `docker` directly. The root package descriptor provides simple scripts to build and start the environment.
 
 ```bash
 # Build the development container


### PR DESCRIPTION
### Summary
The root README previously lacked direct instructions on container engine compatibility. This change adds a clear command substitution note for users running Docker instead of Podman. This improves the usability of the local container setup instructions.

### List of Changes
- Add a direct instruction to the local setup section explaining how to substitute podman commands with docker.
- Enhance setup readability by using direct, action-oriented instructions without third-party references.

### Verification
- [x] Verified markdown formatting in the root README file

