### PR TITLE
fix(ci): ensure build dependencies are installed on deployment runner

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -73,6 +73,8 @@ jobs:
 
       - name: Install all dependencies
         run: npm ci
+        env:
+          NODE_ENV: development
 
       - name: Build shared package
         run: npm run build:shared
@@ -132,6 +134,8 @@ jobs:
 
       - name: Install all dependencies
         run: npm ci
+        env:
+          NODE_ENV: development
 
       - name: Build Shared
         run: npm run build:shared


### PR DESCRIPTION
### Summary
The infrastructure deployment pipeline previously failed during the Next.js compilation step due to missing TypeScript devDependencies on the runner. This change configures the package installation steps to explicitly run in a development node environment. This guarantees that all required compilation tools are installed on the build runner before packaging the application.

### List of Changes
- Configure NODE_ENV to development during npm ci in the API deployment job to ensure build-time dependencies are resolved.
- Set NODE_ENV to development during dependency installation in the frontend deployment job to prevent Next.js compilation failures.

### Verification
- [x] Verified workflow configuration syntax locally

