### PR TITLE
fix(frontend): resolve nextjs compilation failure by relocating typescript

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -73,8 +73,6 @@ jobs:
 
       - name: Install all dependencies
         run: npm ci
-        env:
-          NODE_ENV: development
 
       - name: Build shared package
         run: npm run build:shared
@@ -134,8 +132,6 @@ jobs:
 
       - name: Install all dependencies
         run: npm ci
-        env:
-          NODE_ENV: development
 
       - name: Build Shared
         run: npm run build:shared

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,24 +12,24 @@
 	},
 	"dependencies": {
 		"@cover-craft/shared": "*",
+		"@types/node": "26.1.0",
+		"@types/react": "^19",
+		"@types/react-dom": "^19",
 		"jszip": "^3.10.1",
 		"next": "16.2.10",
 		"react": "19.2.7",
 		"react-dom": "19.2.7",
-		"recharts": "^3.9.2"
+		"recharts": "^3.9.2",
+		"typescript": "^7.0.2"
 	},
 	"devDependencies": {
 		"@tailwindcss/postcss": "^4.3.2",
 		"@testing-library/jest-dom": "^6.9.1",
 		"@testing-library/react": "^16.3.2",
-		"@types/node": "26.1.0",
-		"@types/react": "^19",
-		"@types/react-dom": "^19",
 		"@vitest/coverage-v8": "^4.1.9",
 		"babel-plugin-react-compiler": "1.0.0",
 		"jsdom": "^29.1.1",
 		"tailwindcss": "^4.3.0",
-		"typescript": "^7.0.2",
 		"vitest": "^4.1.10"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,24 +45,24 @@
 			"version": "0.1.0",
 			"dependencies": {
 				"@cover-craft/shared": "*",
+				"@types/node": "26.1.0",
+				"@types/react": "^19",
+				"@types/react-dom": "^19",
 				"jszip": "^3.10.1",
 				"next": "16.2.10",
 				"react": "19.2.7",
 				"react-dom": "19.2.7",
-				"recharts": "^3.9.2"
+				"recharts": "^3.9.2",
+				"typescript": "^7.0.2"
 			},
 			"devDependencies": {
 				"@tailwindcss/postcss": "^4.3.2",
 				"@testing-library/jest-dom": "^6.9.1",
 				"@testing-library/react": "^16.3.2",
-				"@types/node": "26.1.0",
-				"@types/react": "^19",
-				"@types/react-dom": "^19",
 				"@vitest/coverage-v8": "^4.1.9",
 				"babel-plugin-react-compiler": "1.0.0",
 				"jsdom": "^29.1.1",
 				"tailwindcss": "^4.3.0",
-				"typescript": "^7.0.2",
 				"vitest": "^4.1.10"
 			}
 		},
@@ -3028,7 +3028,6 @@
 			"version": "26.1.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
 			"integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~8.3.0"
@@ -3038,7 +3037,6 @@
 			"version": "19.2.14",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.2.2"
@@ -3048,7 +3046,6 @@
 			"version": "19.2.3",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
 			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
@@ -3113,7 +3110,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3130,7 +3126,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3147,7 +3142,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3164,7 +3158,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3181,7 +3174,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3198,7 +3190,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3215,7 +3206,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3232,7 +3222,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3249,7 +3238,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3266,7 +3254,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3283,7 +3270,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3300,7 +3286,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3317,7 +3302,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3334,7 +3318,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3351,7 +3334,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3368,7 +3350,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3385,7 +3366,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3402,7 +3382,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3419,7 +3398,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3436,7 +3414,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -4538,7 +4515,6 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/d3-array": {
@@ -9793,7 +9769,6 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
 			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc"
@@ -9857,7 +9832,6 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
 			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/universalify": {


### PR DESCRIPTION
### Summary
The Next.js build step previously failed during deployment due to TypeScript resolution issues in the hoisted monorepo environment. This change relocates typescript and its associated type definition packages to the direct dependencies of the frontend workspace. It also reverts the temporary build environment override to restore standard production dependency exclusions on the runner.

### List of Changes
- Move typescript and type packages from devDependencies to dependencies in the frontend workspace package descriptor.
- Revert the temporary NODE_ENV override in the deployment workflow to restore standard production package stripping.

### Verification
- [x] Verified local package-lock synchronization after relocating dependencies

