### PR TITLE
fix(frontend): bypass build type-checking and add CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,12 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
-      - name: Run lint
-        run: npm run lint
+      - name: Build shared package
+        run: npm run build:shared
+      - name: Run lint and typecheck
+        run: |
+          npm run lint
+          npm run typecheck
 
   test-api:
     runs-on: ubuntu-latest

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,6 +5,9 @@ const nextConfig: NextConfig = {
 	output: "standalone",
 	reactCompiler: true,
 	transpilePackages: ["@cover-craft/shared"],
+	typescript: {
+		ignoreBuildErrors: true,
+	},
 };
 
 export default nextConfig;

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -1,3 +1,4 @@
+import type { MetricPayload } from "@cover-craft/shared";
 import type { MockedFunction } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -265,7 +266,7 @@ describe("API Service Wrapper", () => {
 			fetchMock.mockResolvedValueOnce({
 				ok: true,
 				json: async () => ({ jobId: "batch-123" }),
-			});
+			} as unknown as Response);
 
 			const result = await generateBatchImages(params);
 
@@ -283,7 +284,7 @@ describe("API Service Wrapper", () => {
 			fetchMock.mockResolvedValueOnce({
 				ok: false,
 				json: async () => ({ error: "Max batch size exceeded" }),
-			});
+			} as unknown as Response);
 
 			await expect(generateBatchImages([])).rejects.toThrow(
 				"Max batch size exceeded",
@@ -304,7 +305,7 @@ describe("API Service Wrapper", () => {
 			fetchMock.mockResolvedValueOnce({
 				ok: true,
 				json: async () => mockResponse,
-			});
+			} as unknown as Response);
 
 			const result = await getBatchJobStatus("job-123");
 
@@ -315,7 +316,7 @@ describe("API Service Wrapper", () => {
 		it("throws error when status fetch fails", async () => {
 			fetchMock.mockResolvedValueOnce({
 				ok: false,
-			});
+			} as unknown as Response);
 
 			await expect(getBatchJobStatus("invalid-id")).rejects.toThrow(
 				"Failed to fetch job status",
@@ -397,7 +398,7 @@ describe("API Service Wrapper", () => {
 			fetchMock.mockResolvedValueOnce({
 				ok: true,
 				json: async () => ({ success: true }),
-			});
+			} as unknown as Response);
 
 			const payload = {
 				width: 1200,
@@ -432,9 +433,11 @@ describe("API Service Wrapper", () => {
 			fetchMock.mockResolvedValueOnce({
 				ok: true,
 				json: async () => ({ success: true }),
-			});
+			} as unknown as Response);
 
-			await sendDownloadEvent({ format: "png" });
+			await sendDownloadEvent({
+				format: "png",
+			} as unknown as Partial<MetricPayload>);
 
 			expect(fetchMock).toHaveBeenCalledWith("/api/metrics", {
 				method: "POST",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
 		"start:api": "mkdir -p __azurite_db__ && azurite --silent --location ./__azurite_db__ & npm run build:shared && npm run start --workspace=api",
 		"docker:build:dev": "podman build -t cover-craft-dev:latest -f Dockerfile.dev .",
 		"docker:run:dev": "podman run -d --rm -p 3000:3000 -p 7071:7071 -p 10000:10000 -p 10001:10001 -p 10002:10002 -v .:/app:Z --name cover-craft-dev-container cover-craft-dev:latest",
-		"docker:clean:dev": "podman rmi cover-craft-dev:latest"
+		"docker:clean:dev": "podman rmi cover-craft-dev:latest",
+		"typecheck": "tsc --noEmit -p frontend/tsconfig.json && tsc --noEmit -p api/tsconfig.json"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.5.3",


### PR DESCRIPTION
### Summary
The Next.js build step failed to resolve the hoisted TypeScript compiler during deployment type-checking. This change configures the Next.js builder to ignore type-checking errors, delegating type verification to a new typecheck command in the continuous integration pipeline. It also resolves existing TypeScript errors in the frontend service test file to restore a clean compilation state.

### List of Changes
- Disable build-time type-checking in Next.js configuration to bypass hoisting resolution issues on the deployment runner.
- Add a typecheck script to the root package descriptor and integrate it into the CI lint pipeline to maintain type safety.
- Correct TypeScript mock casting and payload validation errors in the frontend service test suite.

### Verification
- [x] Executed local type-checking and verified compilation with zero errors
- [x] Verified that Biome linter checks pass with zero formatting warnings

