### PR TITLE
fix(ci): downgrade build runner to node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 env:
-  NODE_VERSION: 24
+  NODE_VERSION: 22
 
 jobs:
   changes:

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -17,7 +17,7 @@ permissions:
   id-token: write
 
 env:
-  NODE_VERSION: '24'
+  NODE_VERSION: '22'
   FRONTEND_APP_NAME: 'cover-craft-ui'
   API_APP_NAME: 'cover-craft'
   RESOURCE_GROUP: 'projects-rg'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,8 +19,7 @@
 		"next": "16.2.10",
 		"react": "19.2.7",
 		"react-dom": "19.2.7",
-		"recharts": "^3.9.2",
-		"typescript": "^7.0.2"
+		"recharts": "^3.9.2"
 	},
 	"devDependencies": {
 		"@tailwindcss/postcss": "^4.3.2",
@@ -30,6 +29,7 @@
 		"babel-plugin-react-compiler": "1.0.0",
 		"jsdom": "^29.1.1",
 		"tailwindcss": "^4.3.0",
+		"typescript": "7.0.2",
 		"vitest": "^4.1.10"
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,8 +52,7 @@
 				"next": "16.2.10",
 				"react": "19.2.7",
 				"react-dom": "19.2.7",
-				"recharts": "^3.9.2",
-				"typescript": "^7.0.2"
+				"recharts": "^3.9.2"
 			},
 			"devDependencies": {
 				"@tailwindcss/postcss": "^4.3.2",
@@ -63,6 +62,7 @@
 				"babel-plugin-react-compiler": "1.0.0",
 				"jsdom": "^29.1.1",
 				"tailwindcss": "^4.3.0",
+				"typescript": "7.0.2",
 				"vitest": "^4.1.10"
 			}
 		},
@@ -873,9 +873,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -893,9 +890,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -913,9 +907,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -933,9 +924,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1812,9 +1800,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1830,9 +1815,6 @@
 			"integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1850,9 +1832,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1868,9 +1847,6 @@
 			"integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2256,9 +2232,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2276,9 +2249,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2296,9 +2266,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2316,9 +2283,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2336,9 +2300,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2356,9 +2317,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2610,9 +2568,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2630,9 +2585,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2650,9 +2602,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2670,9 +2619,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3110,6 +3056,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3126,6 +3073,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3142,6 +3090,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3158,6 +3107,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3174,6 +3124,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3190,6 +3141,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3206,6 +3158,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3222,6 +3175,7 @@
 			"cpu": [
 				"loong64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3238,6 +3192,7 @@
 			"cpu": [
 				"mips64el"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3254,6 +3209,7 @@
 			"cpu": [
 				"ppc64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3270,6 +3226,7 @@
 			"cpu": [
 				"riscv64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3286,6 +3243,7 @@
 			"cpu": [
 				"s390x"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3302,6 +3260,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3318,6 +3277,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3334,6 +3294,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3350,6 +3311,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3366,6 +3328,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3382,6 +3345,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3398,6 +3362,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -3414,6 +3379,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -9769,6 +9735,7 @@
 			"version": "7.0.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
 			"integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc"


### PR DESCRIPTION
### Summary
The CI/CD build pipelines encountered type package resolution errors on the Node 24 runtime due to strict exports map checks. This change configures the continuous integration and deployment workflows to build on the Node 22 LTS runtime instead. It also restores TypeScript to the development dependencies of the frontend workspace for clean separation.

### List of Changes
- Revert Node version from 24 to 22 in CI and deployment workflows to match production and fix lookup errors.
- Restore TypeScript from dependencies to devDependencies in the frontend package descriptor.

### Verification
- [x] Verified successful local package-lock regeneration

