### PR TITLE
fix(ci): use install-links to resolve typescript for next build

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -133,7 +133,7 @@ jobs:
           cache: 'npm'
 
       - name: Install all dependencies
-        run: npm ci
+        run: npm ci --install-links
         env:
           NODE_ENV: development
 


### PR DESCRIPTION
### Summary
`npm ci` in a workspace monorepo hoists devDependencies to the root `node_modules/`, leaving `frontend/node_modules/typescript` absent. Next.js 16 checks that path directly and triggers an inline `npm install typescript` mid-build, which fails in CI. Adding `--install-links` forces npm to populate each workspace's local `node_modules/` with its declared dependencies, eliminating the inline auto-install entirely.

### List of Changes
- Added `--install-links` to `npm ci` in the `deploy-frontend` job so `typescript` is resolvable at `frontend/node_modules/typescript` as Next.js 16 requires.


