### PR TITLE
feat(apiv2): setup local dev container and PM2 process config

### DIFF
--- a/Dockerfile.v2
+++ b/Dockerfile.v2
@@ -1,0 +1,91 @@
+# ==============================================================================
+# Development Dockerfile V2 (Node.js + Go 1.26)
+# ==============================================================================
+# Build command:
+#   podman build -t cover-craft-dev-v2:latest -f Dockerfile.v2 .
+#
+# Run command (with volume mount and port mappings):
+#   podman run -d --rm \
+#     -p 3000:3000 \
+#     -p 7071:7071 \
+#     -p 10000:10000 \
+#     -p 10001:10001 \
+#     -p 10002:10002 \
+#     -v .:/app:Z \
+#     --name cover-craft-dev-container-v2 \
+#     cover-craft-dev-v2:latest
+# ==============================================================================
+
+# Stage 1: Get Go 1.26 compiler from official image
+FROM golang:1.26-alpine AS go-source
+
+# Stage 2: Final dev container with Node.js + Go
+FROM node:lts-bookworm-slim
+WORKDIR /app
+
+# Install native dependencies for node-canvas, process management, and utils
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libcairo2-dev \
+    libpango1.0-dev \
+    libjpeg-dev \
+    libgif-dev \
+    librsvg2-dev \
+    libcairo2 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libjpeg62-turbo \
+    libgif7 \
+    librsvg2-2 \
+    procps \
+    ca-certificates \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy Go compiler directly from the Go source stage
+COPY --from=go-source /usr/local/go/ /usr/local/go/
+ENV PATH=$PATH:/usr/local/go/bin
+
+# Install PM2 and Azure Functions Core Tools globally
+RUN npm install -g pm2 azure-functions-core-tools@4
+
+# Copy package descriptors first to build a cache
+COPY package.json package-lock.json ./
+COPY shared/package.json ./shared/
+COPY api/package.json ./api/
+COPY frontend/package.json ./frontend/
+COPY apiv2/go.mod apiv2/go.sum* ./apiv2/
+
+# Clean install all Node dependencies (including devDependencies)
+RUN npm ci
+
+# Copy the rest of the workspace files
+COPY . .
+
+# Expose ports for frontend, api, and azurite
+EXPOSE 3000 7071 10000 10001 10002
+
+# Write startup entrypoint script to handle dynamic node_modules and compilation
+RUN echo '#!/bin/bash\n\
+set -e\n\
+\n\
+# Install dependencies if they are missing from the mounted volume\n\
+if [ ! -d "node_modules" ]; then\n\
+  echo "Missing node_modules in volume. Installing..."\n\
+  npm install\n\
+fi\n\
+\n\
+# Build the shared library initially\n\
+npm run build:shared\n\
+\n\
+# Compile the Go Azure Functions binary initially\n\
+cd /app/apiv2\n\
+make build\n\
+cd /app\n\
+\n\
+# Start PM2 dev processes for v2\n\
+exec pm2-runtime /app/processes.dev.v2.json' > /usr/local/bin/entrypoint.sh && \
+    chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: docker-build docker-run docker-stop docker-logs docker-shell docker-clean help
+
+docker-build: ## Build the V2 dev container image using Podman
+	podman build -t cover-craft-dev-v2:latest -f Dockerfile.v2 .
+
+docker-run: ## Run the V2 dev container with volume mounts and port mappings
+	podman run -d --rm \
+		-p 3000:3000 \
+		-p 7071:7071 \
+		-p 10000:10000 \
+		-p 10001:10001 \
+		-p 10002:10002 \
+		-v .:/app:Z \
+		--name cover-craft-dev-container-v2 \
+		cover-craft-dev-v2:latest
+
+docker-stop: ## Stop the running V2 dev container
+	podman stop cover-craft-dev-container-v2
+
+docker-logs: ## Tail the logs of the running V2 container
+	podman logs -f cover-craft-dev-container-v2
+
+docker-shell: ## Open an interactive bash shell inside the running V2 container
+	podman exec -it cover-craft-dev-container-v2 /bin/bash
+
+docker-clean: ## Remove the V2 dev container image
+	podman rmi cover-craft-dev-v2:latest
+
+help: ## Show this help message
+	@echo "Usage: make [target]"
+	@echo ""
+	@echo "Available targets:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-15s %s\n", $$1, $$2}'

--- a/processes.dev.v2.json
+++ b/processes.dev.v2.json
@@ -1,0 +1,45 @@
+{
+  "apps": [
+    {
+      "name": "shared-watch",
+      "script": "npx",
+      "args": "tsc -p shared/tsconfig.json -w",
+      "cwd": "/app"
+    },
+    {
+      "name": "apiv2-build",
+      "script": "make",
+      "args": "build",
+      "cwd": "/app/apiv2",
+      "watch": ["cmd", "internal"],
+      "watch_options": {
+        "followSymlinks": false
+      },
+      "autorestart": false
+    },
+    {
+      "name": "apiv2",
+      "script": "func",
+      "args": "start --host localhost",
+      "cwd": "/app/apiv2",
+      "interpreter": "none",
+      "watch": ["bin/apiv2-handler"],
+      "watch_options": {
+        "followSymlinks": false
+      }
+    },
+    {
+      "name": "frontend",
+      "script": "npm",
+      "args": "run dev --workspace=frontend",
+      "cwd": "/app"
+    },
+    {
+      "name": "azurite",
+      "script": "/app/node_modules/.bin/azurite",
+      "args": "--silent --location /app/__azurite_db__",
+      "cwd": "/app",
+      "interpreter": "none"
+    }
+  ]
+}


### PR DESCRIPTION
### Summary
This PR introduces the local development container environment for the Go API (v2) migration. It creates a new `Dockerfile.v2` utilizing multi-stage compiler mirroring, a `processes.dev.v2.json` config to orchestrate PM2 processes, and a root `Makefile` to manage the container lifecycle.

### List of Changes
- Create `Dockerfile.v2` in the root directory copying the Go 1.26 compiler from `golang:1.26-alpine` to support development volume mounts.
- Create `processes.dev.v2.json` at root to run Next.js, Azurite, and Go, watching Go source directories for compilation on change.
- Create a root-level `Makefile` to compile, run, stop, shell, clean, and output help for the new dev container.

### Verification
- [x] Verify root Makefile target help menu: `make help`
- [x] Verify local container image builds successfully: `make docker-build`

