### PR TITLE
feat(apiv2): implement local batch submission and status polling APIs

### DIFF
--- a/apiv2/cmd/handler/main.go
+++ b/apiv2/cmd/handler/main.go
@@ -1,13 +1,16 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/victoriacheng15/cover-craft/apiv2/internal/db"
 	"github.com/victoriacheng15/cover-craft/apiv2/internal/handlers"
+	"github.com/victoriacheng15/cover-craft/apiv2/internal/queue"
 )
 
 func main() {
@@ -30,14 +33,38 @@ func main() {
 		log.Println("MongoDB connection established.")
 	}
 
-	// 3. Configure HTTP Handlers
+	// 3. Initialize Queue Connection
+	storageConn := os.Getenv("AzureWebJobsStorage")
+	if storageConn == "" {
+		log.Println("Warning: AzureWebJobsStorage not set. Queue operations will fail.")
+	} else {
+		log.Printf("Connecting to Azure Queue Storage...")
+		err := queue.InitQueue(storageConn, "batch-jobs")
+		if err != nil {
+			log.Fatalf("Failed to initialize Queue service: %v", err)
+		}
+
+		// Verify/create queue asynchronously at startup
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err = queue.QueueClientService.CreateQueueIfNotExists(ctx)
+		cancel()
+		if err != nil {
+			log.Printf("Warning: failed to verify/create queue 'batch-jobs': %v", err)
+		} else {
+			log.Println("Queue Storage connection established.")
+		}
+	}
+
+	// 4. Configure HTTP Handlers
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/health", handlers.HealthHandler)
 	mux.HandleFunc("/api/analytics", handlers.AnalyticsHandler)
 	mux.HandleFunc("/api/metrics", handlers.MetricsHandler)
 	mux.HandleFunc("/api/generateImage", handlers.GenerateImageHandler)
+	mux.HandleFunc("/api/generateImages", handlers.GenerateImagesHandler)
+	mux.HandleFunc("/api/getJobStatus", handlers.GetJobStatusHandler)
 
-	// 4. Start Server
+	// 5. Start Server
 	listenAddr := fmt.Sprintf(":%s", port)
 	log.Printf("Go Azure Functions Custom Handler listening on %s", listenAddr)
 	log.Fatal(http.ListenAndServe(listenAddr, mux))

--- a/apiv2/go.mod
+++ b/apiv2/go.mod
@@ -8,6 +8,9 @@ require (
 )
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1 // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
@@ -16,8 +19,9 @@ require (
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
-	golang.org/x/crypto v0.17.0 // indirect
+	golang.org/x/crypto v0.37.0 // indirect
 	golang.org/x/image v0.44.0 // indirect
+	golang.org/x/net v0.39.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 )

--- a/apiv2/go.sum
+++ b/apiv2/go.sum
@@ -1,3 +1,9 @@
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0 h1:Gt0j3wceWMwPmiazCa8MzMA0MfhmPIz0Qp0FJ6qcM0U=
+github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1 h1:FPKJS1T+clwv+OLGt13a8UjqeRuh0O4SJ3lUriThc+4=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.1/go.mod h1:j2chePtV91HrC22tGoRX3sGY42uF13WzmmV80/OdVAA=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1 h1:qvrrnQ2mIjwY7IVlQuNB0ma43Nr74+9ZTZJ60KlmlV4=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue v1.0.1/go.mod h1:FkF/Az07vR3S4sBdjCuisznWfFWOD8u6Ibm/g/oyDAk=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fogleman/gg v1.3.0 h1:/7zJX8F6AaYQc57WQCyN9cAIz+4bCJGO9B+dyW29am8=
@@ -27,12 +33,16 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.17.0 h1:r8bRNjWL3GshPW3gkd+RpvzWrZAwPS49OmTGZ/uhM4k=
 golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+golang.org/x/crypto v0.37.0 h1:kJNSjF/Xp7kU0iB2Z+9viTPMW4EqqsrywMXLJOOsXSE=
+golang.org/x/crypto v0.37.0/go.mod h1:vg+k43peMZ0pUMhYmVAWysMK35e6ioLh3wB8ZCAfbVc=
 golang.org/x/image v0.44.0 h1:+tDekMZED9+LrtB3G5xzRggpVh9CARjZqROla3R3R+I=
 golang.org/x/image v0.44.0/go.mod h1:V8K3KE9KKKE+pLpQDOeN18w9oacNSvy1tDOirTu4xtY=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
+golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.22.0 h1:SZjpbeLmrCk4xhRSZFNZW5gFUeCeFgjekvI/+gfScek=

--- a/apiv2/internal/db/mongo.go
+++ b/apiv2/internal/db/mongo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -11,6 +12,30 @@ import (
 type SizePreset struct {
 	Width  int `bson:"width,omitempty" json:"width,omitempty"`
 	Height int `bson:"height,omitempty" json:"height,omitempty"`
+}
+
+type JobResult struct {
+	Index     int       `bson:"index" json:"index"`
+	Status    string    `bson:"status" json:"status"`
+	DataURL   string    `bson:"dataUrl,omitempty" json:"dataUrl,omitempty"`
+	Error     string    `bson:"error,omitempty" json:"error,omitempty"`
+	Attempts  int       `bson:"attempts" json:"attempts"`
+	UpdatedAt time.Time `bson:"updatedAt" json:"updatedAt"`
+}
+
+type Job struct {
+	ID                  primitive.ObjectID   `bson:"_id,omitempty" json:"id"`
+	Status              string               `bson:"status" json:"status"`
+	Requests            []interface{}        `bson:"requests" json:"requests"`
+	Results             []string             `bson:"results" json:"results"`
+	Error               string               `bson:"error,omitempty" json:"error,omitempty"`
+	Attempts            int                  `bson:"attempts" json:"attempts"`
+	MaxAttempts         int                  `bson:"maxAttempts" json:"maxAttempts"`
+	ProcessingStartedAt *time.Time           `bson:"processingStartedAt,omitempty" json:"processingStartedAt,omitempty"`
+	LastError           string               `bson:"lastError,omitempty" json:"lastError,omitempty"`
+	ResultDetails       map[string]JobResult `bson:"resultDetails" json:"resultDetails"`
+	CreatedAt           time.Time            `bson:"createdAt" json:"createdAt"`
+	UpdatedAt           time.Time            `bson:"updatedAt" json:"updatedAt"`
 }
 
 type Metric struct {

--- a/apiv2/internal/handlers/batch.go
+++ b/apiv2/internal/handlers/batch.go
@@ -1,0 +1,279 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+
+	"github.com/victoriacheng15/cover-craft/apiv2/internal/db"
+	"github.com/victoriacheng15/cover-craft/apiv2/internal/queue"
+	"github.com/victoriacheng15/cover-craft/apiv2/internal/services"
+)
+
+// GenerateImagesHandler handles bulk image generation job creation (POST /api/generateImages)
+func GenerateImagesHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var requests []services.ImageParams
+	err := json.NewDecoder(r.Body).Decode(&requests)
+	if err != nil {
+		writeJSONError(w, "Payload must be a JSON array of image configurations.", http.StatusBadRequest)
+		return
+	}
+
+	// 1. Perform bulk validation checks
+	validationErrors := services.ValidateBatchRequest(requests)
+	if len(validationErrors) > 0 {
+		log.Printf("Batch validation failed: %d errors", len(validationErrors))
+
+		// Capture individual validation metrics asynchronously
+		go func(reqs []services.ImageParams, errs []services.ValidationError) {
+			for i, item := range reqs {
+				contrastRatio, _ := services.GetContrastRatio(item.BackgroundColor, item.TextColor)
+				wcagLevel := services.GetWCAGLevel(contrastRatio)
+
+				var itemErrors []string
+				prefix := fmt.Sprintf("requests[%d].", i)
+				for _, e := range errs {
+					if strings.HasPrefix(e.Field, prefix) {
+						itemErrors = append(itemErrors, e.Message)
+					}
+				}
+
+				errMsg := "Validation failed"
+				if len(itemErrors) > 0 {
+					errMsg = strings.Join(itemErrors, "; ")
+				}
+				if len(errMsg) > 1000 {
+					errMsg = errMsg[:1000]
+				}
+
+				var subLen int
+				if item.Subtitle != nil {
+					subLen = len(*item.Subtitle)
+				}
+
+				storeMetric(db.Metric{
+					Event:          "image_generated",
+					Timestamp:      time.Now().UTC(),
+					Status:         "validation_error",
+					ErrorMessage:   errMsg,
+					Size:           &db.SizePreset{Width: item.Width, Height: item.Height},
+					Font:           string(item.Font),
+					TitleLength:    intPtr(len(item.Title)),
+					SubtitleLength: intPtr(subLen),
+					ContrastRatio:  floatPtr(contrastRatio),
+					WcagLevel:      wcagLevel,
+				})
+			}
+		}(requests, validationErrors)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":   "Validation failed",
+			"details": validationErrors,
+		})
+		return
+	}
+
+	// 2. Provision Pending Job in MongoDB
+	jobId := primitive.NewObjectID()
+	now := time.Now().UTC()
+
+	requestsInterfaces := make([]interface{}, len(requests))
+	for i, r := range requests {
+		requestsInterfaces[i] = r
+	}
+
+	job := db.Job{
+		ID:            jobId,
+		Status:        "pending",
+		Requests:      requestsInterfaces,
+		Results:       []string{},
+		Attempts:      0,
+		MaxAttempts:   3,
+		ResultDetails: make(map[string]db.JobResult),
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+
+	if db.MongoClient != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_, err = db.MongoClient.Database("cover-craft").Collection("jobs").InsertOne(ctx, job)
+		cancel()
+		if err != nil {
+			log.Printf("Failed to insert job into MongoDB: %v", err)
+			writeJSONError(w, "Failed to provision batch job", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		log.Println("Warning: MongoDB client not configured. Proceeding without database.")
+	}
+
+	// 3. Connect to Azure Queue Storage and publish Job ID
+	if queue.QueueClientService != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err = queue.QueueClientService.EnqueueJob(ctx, jobId.Hex())
+		cancel()
+		if err != nil {
+			log.Printf("Failed to enqueue job message in Queue: %v", err)
+			writeJSONError(w, "Failed to enqueue batch job task", http.StatusInternalServerError)
+			return
+		}
+	} else {
+		log.Println("Warning: Queue service not configured. Proceeding without enqueuing task.")
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"message": "Batch job accepted for processing.",
+		"id":      jobId.Hex(),
+		"jobId":   jobId.Hex(),
+	})
+}
+
+// GetJobStatusHandler handles polling for job progress (GET /api/getJobStatus)
+func GetJobStatusHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	jobId := r.URL.Query().Get("jobId")
+	if jobId == "" {
+		writeJSONError(w, "Missing jobId query parameter", http.StatusBadRequest)
+		return
+	}
+
+	if db.MongoClient == nil {
+		writeJSONError(w, "Database connection not available", http.StatusInternalServerError)
+		return
+	}
+
+	var job db.Job
+	var err error
+	collection := db.MongoClient.Database("cover-craft").Collection("jobs")
+
+	// 1. Try full ObjectID lookup first
+	if len(jobId) == 24 && regexp.MustCompile(`^[0-9a-fA-F]{24}$`).MatchString(jobId) {
+		objID, parseErr := primitive.ObjectIDFromHex(jobId)
+		if parseErr == nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			err = collection.FindOne(ctx, bson.M{"_id": objID}).Decode(&job)
+			cancel()
+		} else {
+			err = mongo.ErrNoDocuments
+		}
+	} else if len(jobId) == 8 && regexp.MustCompile(`^[0-9a-fA-F]{8}$`).MatchString(jobId) {
+		// 2. Try partial lookup for 8-character hex strings (last 8 chars)
+		pipeline := mongo.Pipeline{
+			{{Key: "$addFields", Value: bson.M{"idStr": bson.M{"$toString": "$_id"}}}},
+			{{Key: "$match", Value: bson.M{"idStr": bson.M{"$regex": jobId + "$"}}}},
+			{{Key: "$limit", Value: 1}},
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		cursor, aggErr := collection.Aggregate(ctx, pipeline)
+		if aggErr == nil {
+			if cursor.Next(ctx) {
+				err = cursor.Decode(&job)
+			} else {
+				err = mongo.ErrNoDocuments
+			}
+			cursor.Close(ctx)
+		} else {
+			err = aggErr
+		}
+		cancel()
+	} else {
+		writeJSONError(w, "Invalid Job ID format. Provide either the full 24-character ID or the last 8 characters.", http.StatusBadRequest)
+		return
+	}
+
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			writeJSONError(w, "Job not found", http.StatusNotFound)
+			return
+		}
+		log.Printf("Database lookup error for jobId %s: %v", jobId, err)
+		writeJSONError(w, "Database error", http.StatusInternalServerError)
+		return
+	}
+
+	results := getFinalResults(job)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	response := map[string]interface{}{
+		"id":        job.ID.Hex(),
+		"status":    job.Status,
+		"progress":  len(results),
+		"total":     len(job.Requests),
+		"results":   results,
+		"createdAt": job.CreatedAt,
+		"updatedAt": job.UpdatedAt,
+	}
+	if job.Error != "" {
+		response["error"] = job.Error
+	}
+	_ = json.NewEncoder(w).Encode(response)
+}
+
+// getFinalResults builds the formatted results list (Urls or errors) sorted by request index
+func getFinalResults(job db.Job) []string {
+	if len(job.ResultDetails) == 0 {
+		if job.Results != nil {
+			return job.Results
+		}
+		return []string{}
+	}
+
+	type indexedResult struct {
+		index int
+		val   string
+	}
+	var items []indexedResult
+	for _, det := range job.ResultDetails {
+		val := fmt.Sprintf("error: %s", det.Error)
+		if det.Status == "success" && det.DataURL != "" {
+			val = det.DataURL
+		} else if det.Error == "" {
+			val = "error: Failed to render"
+		}
+		items = append(items, indexedResult{index: det.Index, val: val})
+	}
+
+	// Sort by index ascending
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].index < items[j].index
+	})
+
+	res := make([]string, len(items))
+	for i, item := range items {
+		res[i] = item.val
+	}
+	return res
+}
+
+// writeJSONError formats and returns a JSON error response
+func writeJSONError(w http.ResponseWriter, message string, statusCode int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(ErrorResponse{Error: message})
+}

--- a/apiv2/internal/handlers/batch_test.go
+++ b/apiv2/internal/handlers/batch_test.go
@@ -1,0 +1,217 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/victoriacheng15/cover-craft/apiv2/internal/db"
+	"github.com/victoriacheng15/cover-craft/apiv2/internal/queue"
+	"github.com/victoriacheng15/cover-craft/apiv2/internal/services"
+)
+
+func TestGenerateImagesHandler(t *testing.T) {
+	tests := []struct {
+		name            string
+		method          string
+		body            interface{}
+		wantStatus      int
+		wantDetailField string
+	}{
+		{
+			name:   "Valid batch request succeeds",
+			method: http.MethodPost,
+			body: []map[string]interface{}{
+				{
+					"width":           800,
+					"height":          600,
+					"backgroundColor": "#ffffff",
+					"textColor":       "#000000",
+					"font":            "Montserrat",
+					"title":           "Batch Item 1",
+					"filename":        "file1",
+				},
+			},
+			wantStatus: http.StatusAccepted,
+		},
+		{
+			name:       "Disallowed method GET returns 405",
+			method:     http.MethodGet,
+			body:       nil,
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "Invalid JSON payload format returns 400",
+			method:     http.MethodPost,
+			body:       "not-a-json-array",
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:            "Validation error - empty batch",
+			method:          http.MethodPost,
+			body:            []interface{}{},
+			wantStatus:      http.StatusBadRequest,
+			wantDetailField: "requests",
+		},
+		{
+			name:   "Validation error - exceeds maximum size of 5",
+			method: http.MethodPost,
+			body: []map[string]interface{}{
+				{"width": 800, "height": 600, "backgroundColor": "#fff", "textColor": "#000", "font": "Roboto", "title": "1", "filename": "1"},
+				{"width": 800, "height": 600, "backgroundColor": "#fff", "textColor": "#000", "font": "Roboto", "title": "2", "filename": "2"},
+				{"width": 800, "height": 600, "backgroundColor": "#fff", "textColor": "#000", "font": "Roboto", "title": "3", "filename": "3"},
+				{"width": 800, "height": 600, "backgroundColor": "#fff", "textColor": "#000", "font": "Roboto", "title": "4", "filename": "4"},
+				{"width": 800, "height": 600, "backgroundColor": "#fff", "textColor": "#000", "font": "Roboto", "title": "5", "filename": "5"},
+				{"width": 800, "height": 600, "backgroundColor": "#fff", "textColor": "#000", "font": "Roboto", "title": "6", "filename": "6"},
+			},
+			wantStatus:      http.StatusBadRequest,
+			wantDetailField: "requests",
+		},
+		{
+			name:   "Validation error - nested parameter invalid",
+			method: http.MethodPost,
+			body: []map[string]interface{}{
+				{
+					"width":           0, // Invalid width
+					"height":          600,
+					"backgroundColor": "#ffffff",
+					"textColor":       "#000000",
+					"font":            "Montserrat",
+					"title":           "Item 1",
+					"filename":        "file1",
+				},
+			},
+			wantStatus:      http.StatusBadRequest,
+			wantDetailField: "requests[0].width",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Ensure clean mocks
+			db.MongoClient = nil
+			queue.QueueClientService = nil
+
+			var reqBody io.Reader
+			if tt.body != nil {
+				jsonBytes, err := json.Marshal(tt.body)
+				if err != nil {
+					t.Fatalf("failed to marshal request body: %v", err)
+				}
+				reqBody = bytes.NewBuffer(jsonBytes)
+			}
+
+			req, err := http.NewRequest(tt.method, "/api/generateImages", reqBody)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.body != nil {
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			rr := httptest.NewRecorder()
+			handler := http.HandlerFunc(GenerateImagesHandler)
+			handler.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tt.wantStatus {
+				t.Errorf("GenerateImagesHandler() returned wrong status: got %v, want %v. Body: %s", status, tt.wantStatus, rr.Body.String())
+			}
+
+			if tt.wantDetailField != "" {
+				var resp struct {
+					Error   string                     `json:"error"`
+					Details []services.ValidationError `json:"details"`
+				}
+				if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+					t.Fatalf("failed to decode error body: %v", err)
+				}
+
+				foundField := false
+				for _, detail := range resp.Details {
+					if detail.Field == tt.wantDetailField {
+						foundField = true
+						break
+					}
+				}
+
+				if !foundField {
+					t.Errorf("expected validation error for field %q, but details were: %+v", tt.wantDetailField, resp.Details)
+				}
+			}
+		})
+	}
+}
+
+func TestGetJobStatusHandler(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		url        string
+		setupMock  bool
+		wantStatus int
+	}{
+		{
+			name:       "Missing jobId parameter returns 400",
+			method:     http.MethodGet,
+			url:        "/api/getJobStatus",
+			setupMock:  true,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "Disallowed method POST returns 405",
+			method:     http.MethodPost,
+			url:        "/api/getJobStatus?jobId=123",
+			setupMock:  true,
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "Nil database client returns 500",
+			method:     http.MethodGet,
+			url:        "/api/getJobStatus?jobId=65f6ba89e0239c7c00000001",
+			setupMock:  false, // No database
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:       "Invalid format Job ID returns 400",
+			method:     http.MethodGet,
+			url:        "/api/getJobStatus?jobId=invalid-id-format",
+			setupMock:  true,
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setupMock {
+				// Establish dummy client config
+				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				defer cancel()
+				client, _ := mongo.Connect(ctx, options.Client().ApplyURI("mongodb://localhost:27017"))
+				db.MongoClient = client
+			} else {
+				db.MongoClient = nil
+			}
+
+			req, err := http.NewRequest(tt.method, tt.url, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder()
+			handler := http.HandlerFunc(GetJobStatusHandler)
+			handler.ServeHTTP(rr, req)
+
+			if status := rr.Code; status != tt.wantStatus {
+				t.Errorf("GetJobStatusHandler() returned wrong status: got %v, want %v. Body: %s", status, tt.wantStatus, rr.Body.String())
+			}
+		})
+	}
+}

--- a/apiv2/internal/queue/azure.go
+++ b/apiv2/internal/queue/azure.go
@@ -1,0 +1,66 @@
+package queue
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azqueue"
+)
+
+// QueueService encapsulates Azure Queue operations
+type QueueService struct {
+	client *azqueue.QueueClient
+}
+
+// QueueClientService is the shared singleton for queue operations
+var QueueClientService *QueueService
+
+// InitQueue initializes the global QueueClientService
+func InitQueue(connectionString, queueName string) error {
+	svc, err := NewQueueService(connectionString, queueName)
+	if err != nil {
+		return err
+	}
+	QueueClientService = svc
+	return nil
+}
+
+// NewQueueService creates a new instance of QueueService
+func NewQueueService(connectionString, queueName string) (*QueueService, error) {
+	serviceClient, err := azqueue.NewServiceClientFromConnectionString(connectionString, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ServiceClient from connection string: %w", err)
+	}
+
+	queueClient := serviceClient.NewQueueClient(queueName)
+	return &QueueService{client: queueClient}, nil
+}
+
+// CreateQueueIfNotExists creates the queue if it doesn't already exist
+func (q *QueueService) CreateQueueIfNotExists(ctx context.Context) error {
+	_, err := q.client.Create(ctx, nil)
+	if err != nil {
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == 409 {
+			// 409 Conflict: QueueAlreadyExists
+			return nil
+		}
+		return fmt.Errorf("failed to create queue: %w", err)
+	}
+	return nil
+}
+
+// EnqueueJob publishes a Job ID message (Base64-encoded) to the queue
+func (q *QueueService) EnqueueJob(ctx context.Context, jobId string) error {
+	// Azure Functions Core Tools expects queue messages to be Base64-encoded strings
+	encodedMsg := base64.StdEncoding.EncodeToString([]byte(jobId))
+
+	_, err := q.client.EnqueueMessage(ctx, encodedMsg, nil)
+	if err != nil {
+		return fmt.Errorf("failed to enqueue message: %w", err)
+	}
+	return nil
+}

--- a/apiv2/internal/services/types.gen.go
+++ b/apiv2/internal/services/types.gen.go
@@ -131,8 +131,8 @@ type ValidationErrorResponse struct {
 // PostGenerateImagesJSONBody defines parameters for PostGenerateImages.
 type PostGenerateImagesJSONBody = []ImageParams
 
-// GetJobStatusParams defines parameters for GetJobStatus.
-type GetJobStatusParams struct {
+// GetGetJobStatusParams defines parameters for GetGetJobStatus.
+type GetGetJobStatusParams struct {
 	JobId string `form:"jobId" json:"jobId"`
 }
 

--- a/apiv2/internal/services/validation.go
+++ b/apiv2/internal/services/validation.go
@@ -181,3 +181,32 @@ func ValidateImageParams(params ImageParams) []ValidationError {
 
 	return errors
 }
+
+// ValidateBatchRequest checks multiple ImageParams constraints for bulk validation
+func ValidateBatchRequest(requests []ImageParams) []ValidationError {
+	var errors []ValidationError
+	if len(requests) == 0 {
+		errors = append(errors, ValidationError{
+			Field:   "requests",
+			Message: "Batch request must contain at least one configuration",
+		})
+		return errors
+	}
+	if len(requests) > 5 {
+		errors = append(errors, ValidationError{
+			Field:   "requests",
+			Message: "Batch size exceeds the maximum limit of 5",
+		})
+		return errors
+	}
+	for i, req := range requests {
+		subErrors := ValidateImageParams(req)
+		for _, err := range subErrors {
+			errors = append(errors, ValidationError{
+				Field:   fmt.Sprintf("requests[%d].%s", i, err.Field),
+				Message: err.Message,
+			})
+		}
+	}
+	return errors
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -114,7 +114,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ValidationErrorResponse'
 
-  /jobStatus:
+  /getJobStatus:
     get:
       summary: Poll status of a bulk generation batch
       description: Returns progress counter, enqueued time, and completed image URLs for a batch Job ID.

--- a/shared/types.gen.ts
+++ b/shared/types.gen.ts
@@ -248,7 +248,7 @@ export interface paths {
 		patch?: never;
 		trace?: never;
 	};
-	"/jobStatus": {
+	"/getJobStatus": {
 		parameters: {
 			query?: never;
 			header?: never;


### PR DESCRIPTION
### Summary
This PR implements the local batch image generation submission (`POST /api/generateImages`) and status polling (`GET /api/getJobStatus`) endpoints in Go. It connects to the MongoDB instance to provision and query Job documents and enqueues Job IDs to the local Azurite Queue Storage emulator.

### List of Changes
- Implement `apiv2/internal/handlers/batch.go` covering request parsing, bulk validation checks, MongoDB job provisioning, and Azurite queue push.
- Implement `apiv2/internal/queue/azure.go` to handle connecting to Azurite Queue storage and pushing base64-encoded messages.
- Implement `apiv2/internal/services/validation.go`'s `ValidateBatchRequest` function supporting limit bounds and nested field error tracking.
- Setup `apiv2/internal/handlers/batch_test.go` table-driven test suite verifying routing constraints, validation rejections, and DB/Queue mock skipping.
- Update `apiv2/cmd/handler/main.go` to initialize the queue client and route `/api/generateImages` and `/api/getJobStatus` endpoints.
- Update `openapi.yaml` path name alignment from `/jobStatus` to `/getJobStatus` to match client routing.

### Verification
- [x] Run Go handler unit test suite: `go test -v ./internal/handlers/...`
- [x] Run formatting and vet validations: `make fmt && make lint` (inside `apiv2/`)

