### PR TITLE
fix(workflow): include handler folder in Go zip deployment

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Package Go API for deployment
         working-directory: apiv2
         run: |
-          zip -r ../go-deploy.zip bin host.json processJobs assets
+          zip -r ../go-deploy.zip bin host.json handler processJobs assets
 
       - name: Azure Login
         uses: azure/login@v3


### PR DESCRIPTION
### Summary
This change fixes the Go deployment packaging configuration by including the `handler` directory in the compiled zip archive. This ensures that the wildcard HTTP trigger configuration (`handler/function.json`) is present during deployment, resolving a trigger synchronization failure that returned a `400 Bad Request` error.

### List of Changes
- Add the `handler` directory to the `zip` command in `.github/workflows/infra-deploy.yml`.
- Ensure the HTTP trigger mappings are registered correctly during automated remote deployment.

### Verification
- [x] Verify YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/infra-deploy.yml'))"`

