### PR TITLE
fix(workflow): use official Azure functions-action for Go deploy

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -152,11 +152,10 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy Go API to Azure Functions
-        run: |
-          az functionapp deployment source config-zip \
-            --name ${{ env.GO_API_APP_NAME }} \
-            --resource-group ${{ env.API_RESOURCE_GROUP }} \
-            --src go-deploy.zip
+        uses: Azure/functions-action@v1
+        with:
+          app-name: ${{ env.GO_API_APP_NAME }}
+          package: go-deploy.zip
 
   deploy-frontend:
     needs: infra-apply


### PR DESCRIPTION
### Summary
This change refactors the Go Function App deployment method by adopting the official `Azure/functions-action@v1` action. This corrects a deployment validation error on standard Linux Consumption plans by allowing the Action to manage the package blob storage mapping and `WEBSITE_RUN_FROM_PACKAGE` updates dynamically.

### List of Changes
- Replace `az functionapp deployment source config-zip` with `uses: Azure/functions-action@v1` in `.github/workflows/infra-deploy.yml`.
- Standardize the automated deployment pipeline for Linux Consumption environments.

### Verification
- [x] Verify YAML syntax: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/infra-deploy.yml'))"`

