### PR TITLE
chore(makefile): consolidate Go and markdown targets at root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,18 @@
-.PHONY: docker-build docker-run docker-stop docker-logs docker-shell docker-clean contract-sync help
+DEV_IMAGE := cover-craft-dev-v2:latest
+DEV_CONTAINER := cover-craft-dev-v2
 
-docker-build: ## Build the V2 dev container image using Podman
-	podman build -t cover-craft-dev-v2:latest -f Dockerfile.v2 .
+.PHONY: dev-build dev-run dev-stop dev-logs dev-shell dev-clean contract-sync \
+	update-go fmt-go lint-go test-go test-bdd test-all-go cov-go cov-bdd build-go run-go clean-go \
+	build-ui run-ui test-ui lint-ui format-ui lint-md format-md help
 
-docker-run: ## Run the V2 dev container with volume mounts and port mappings
+# ==============================================================================
+# Local Dev Env
+# ==============================================================================
+
+dev-build: ## Build the V2 dev container image using Podman
+	podman build -t $(DEV_IMAGE) -f Dockerfile.v2 .
+
+dev-run: ## Run the V2 dev container with volume mounts and port mappings
 	podman run -d --rm \
 		-p 3000:3000 \
 		-p 7071:7071 \
@@ -11,23 +20,90 @@ docker-run: ## Run the V2 dev container with volume mounts and port mappings
 		-p 10001:10001 \
 		-p 10002:10002 \
 		-v .:/app:Z \
-		--name cover-craft-dev-container-v2 \
-		cover-craft-dev-v2:latest
+		--name $(DEV_CONTAINER) \
+		$(DEV_IMAGE)
 
-docker-stop: ## Stop the running V2 dev container
-	podman stop cover-craft-dev-container-v2
+dev-stop: ## Stop the running V2 dev container
+	podman stop $(DEV_CONTAINER)
 
-docker-logs: ## Tail the logs of the running V2 container
-	podman logs -f cover-craft-dev-container-v2
+dev-logs: ## Tail the logs of the running V2 container
+	podman logs -f $(DEV_CONTAINER)
 
-docker-shell: ## Open an interactive bash shell inside the running V2 container
-	podman exec -it cover-craft-dev-container-v2 /bin/bash
+dev-shell: ## Open an interactive bash shell inside the running V2 container
+	podman exec -it $(DEV_CONTAINER) /bin/bash
 
-docker-clean: ## Remove the V2 dev container image
-	podman rmi cover-craft-dev-v2:latest
+dev-clean: ## Remove the V2 dev container image
+	podman rmi $(DEV_IMAGE)
 
 contract-sync: ## Synchronize API contracts and regenerate Go/TS types
 	./scripts/sync-contracts.sh
+
+# ==============================================================================
+# Markdown
+# ==============================================================================
+
+lint-md: ## Run markdown linter checks
+	npx markdownlint-cli "**/*.md" --ignore "**/node_modules/**"
+
+format-md: ## Automatically fix markdown formatting issues
+	npx markdownlint-cli "**/*.md" --fix --ignore "**/node_modules/**"
+
+# ==============================================================================
+# Go API (apiv2)
+# ==============================================================================
+
+update-go: ## Update Go dependencies and tidy go.mod
+	cd apiv2 && go get -u ./... && go mod tidy && cd ..
+
+fmt-go: ## Format Go source files
+	cd apiv2 && go fmt ./cmd/... ./internal/... ./e2e/... && cd ..
+
+lint-go: ## Run static analysis checks on Go API (go vet)
+	cd apiv2 && go vet ./cmd/... ./internal/... ./e2e/... && cd ..
+
+test-go: ## Run Go unit tests
+	cd apiv2 && go test ./internal/... && cd ..
+
+test-bdd: ## Run Go BDD end-to-end features
+	cd apiv2 && go test ./e2e/... && cd ..
+
+test-all-go: ## Run all Go unit and BDD tests
+	cd apiv2 && go test ./internal/... && go test ./e2e/... && cd ..
+
+cov-go: ## Run Go unit tests and print terminal coverage summary
+	cd apiv2 && go test -coverprofile=coverage.out ./internal/... && go tool cover -func=coverage.out && rm -f coverage.out && cd ..
+
+cov-bdd: ## Run Go BDD features and print coverage summary
+	cd apiv2 && go test -count=1 -coverprofile=coverage_bdd.out -coverpkg=./internal/... ./e2e/... && go tool cover -func=coverage_bdd.out && rm -f coverage_bdd.out && cd ..
+
+build-go: ## Compile the Go application binary
+	cd apiv2 && mkdir -p bin && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o bin/apiv2-handler cmd/handler/main.go && cd ..
+
+run-go: build-go ## Compile Go binary, start Azurite in background, and start Functions host
+	mkdir -p __azurite_db__
+	npx azurite --silent --location ./__azurite_db__ &
+	cd apiv2 && func start && cd ..
+
+clean-go: ## Remove Go build and coverage artifacts
+	cd apiv2 && rm -rf bin/ coverage.out coverage_bdd.out && cd ..
+
+# ==============================================================================
+# Frontend
+# ==============================================================================
+
+build-ui: ## Build the Next.js production bundle
+
+run-ui: ## Start the Next.js development server
+
+test-ui: ## Run frontend Vitest tests
+
+lint-ui: ## Run linter checks for frontend code using Biome
+
+format-ui: ## Format frontend source files using Biome
+
+# ==============================================================================
+# Help
+# ==============================================================================
 
 help: ## Show this help message
 	@echo "Usage: make [target]"


### PR DESCRIPTION
### Summary
This change consolidates all Go API and markdown linter Makefile targets into the root Makefile. It implements explicit directory-changing syntax (using `&& cd ..`) for safety, adds local dev image/container variables, and defines placeholder targets for frontend UI orchestration.

### List of Changes
- Declare `DEV_IMAGE` and `DEV_CONTAINER` variables at the top of the root Makefile and rename all local dev container targets to use the `dev-` prefix.
- Add Go API targets (`update-go`, `fmt-go`, `lint-go`, etc.) and markdown targets (`lint-md`, `format-md`) to the root Makefile.
- Add empty placeholder UI orchestration targets (`build-ui`, `run-ui`, `test-ui`, etc.) to establish future structure.

### Verification
- [x] Print available make targets: `make help`

