### PR TITLE
refactor(tofu): route frontend to go api and consolidate module

### DIFF
--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -91,73 +91,24 @@ module "function_app" {
   tags                             = local.tags
 }
 
-data "azurerm_function_app_host_keys" "api" {
-  name                = var.app_name
-  resource_group_name = azurerm_resource_group.api.name
-
-  depends_on = [module.function_app]
-}
-
 # 4. App Service Module (Plan & Frontend)
 module "app_service" {
   source              = "./modules/app_service"
   resource_group_name = data.azurerm_resource_group.main.name
   location            = var.location
   app_name            = var.app_name
-  azure_function_key  = data.azurerm_function_app_host_keys.api.default_function_key
+  azure_function_key  = module.function_app.go_api_default_key
   tags                = local.tags
-}
-
-# Temporary Go Backend Infrastructure (Consumption Plan Y1 + Linux Custom Runtime App)
-resource "azurerm_service_plan" "go_plan" {
-  name                = "asp-${var.app_name}-go"
-  resource_group_name = azurerm_resource_group.api.name
-  location            = var.location
-  os_type             = "Linux"
-  sku_name            = "Y1"
-  tags                = local.tags
-}
-
-resource "azurerm_linux_function_app" "go_api" {
-  name                = "${var.app_name}-go-api"
-  resource_group_name = azurerm_resource_group.api.name
-  location            = var.location
-
-  service_plan_id            = azurerm_service_plan.go_plan.id
-  storage_account_name       = module.storage.name
-  storage_account_access_key = module.storage.primary_access_key
-
-  site_config {
-    application_stack {
-      use_custom_runtime = true
-    }
-  }
-
-  app_settings = {
-    "FUNCTIONS_WORKER_RUNTIME"              = "custom"
-    "MONGODB_URI"                           = var.mongodb_uri
-    "APPINSIGHTS_INSTRUMENTATIONKEY"        = module.application_insights.instrumentation_key
-    "APPLICATIONINSIGHTS_CONNECTION_STRING" = module.application_insights.connection_string
-  }
-
-  tags = local.tags
-}
-
-data "azurerm_function_app_host_keys" "go_api" {
-  name                = azurerm_linux_function_app.go_api.name
-  resource_group_name = azurerm_resource_group.api.name
-
-  depends_on = [azurerm_linux_function_app.go_api]
 }
 
 # Go API Output Endpoints for Testing
 output "go_api_url" {
-  value       = "https://${azurerm_linux_function_app.go_api.default_hostname}"
+  value       = module.function_app.go_api_url
   description = "The default hostname of the Go Custom Handler Function App"
 }
 
 output "go_api_default_key" {
-  value       = data.azurerm_function_app_host_keys.go_api.default_function_key
+  value       = module.function_app.go_api_default_key
   sensitive   = true
   description = "The default host key of the Go Custom Handler Function App"
 }

--- a/tofu/modules/app_service/main.tf
+++ b/tofu/modules/app_service/main.tf
@@ -44,7 +44,7 @@ resource "azurerm_linux_web_app" "frontend" {
   }
 
   app_settings = {
-    "AZURE_FUNCTION_URL" = "https://${var.app_name}.azurewebsites.net/api"
+    "AZURE_FUNCTION_URL" = "https://${var.app_name}-go-api.azurewebsites.net/api"
     "AZURE_FUNCTION_KEY" = var.azure_function_key
     "NODE_ENV"           = "production"
   }

--- a/tofu/modules/function_app/main.tf
+++ b/tofu/modules/function_app/main.tf
@@ -91,3 +91,70 @@ resource "azurerm_function_app_flex_consumption" "api" {
     "APPLICATIONINSIGHTS_CONNECTION_STRING" = var.app_insights_connection_string
   }
 }
+
+# Go API Plan (Consumption Y1)
+resource "azurerm_service_plan" "go_plan" {
+  name                = "asp-${var.app_name}-go"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  os_type             = "Linux"
+  sku_name            = "Y1"
+  tags                = var.tags
+}
+
+# Go Function App (Custom Runtime)
+resource "azurerm_linux_function_app" "go_api" {
+  name                = "${var.app_name}-go-api"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  service_plan_id            = azurerm_service_plan.go_plan.id
+  storage_account_name       = var.storage_account_name
+  storage_account_access_key = var.storage_account_access_key
+
+  site_config {
+    application_stack {
+      use_custom_runtime = true
+    }
+  }
+
+  app_settings = {
+    "FUNCTIONS_WORKER_RUNTIME"              = "custom"
+    "MONGODB_URI"                           = var.mongodb_uri
+    "APPINSIGHTS_INSTRUMENTATIONKEY"        = var.app_insights_instrumentation_key
+    "APPLICATIONINSIGHTS_CONNECTION_STRING" = var.app_insights_connection_string
+  }
+
+  tags = var.tags
+}
+
+# Host Keys for Legacy API
+data "azurerm_function_app_host_keys" "api" {
+  name                = azurerm_function_app_flex_consumption.api.name
+  resource_group_name = var.resource_group_name
+
+  depends_on = [azurerm_function_app_flex_consumption.api]
+}
+
+# Host Keys for Go API
+data "azurerm_function_app_host_keys" "go_api" {
+  name                = azurerm_linux_function_app.go_api.name
+  resource_group_name = var.resource_group_name
+
+  depends_on = [azurerm_linux_function_app.go_api]
+}
+
+# Outputs
+output "default_function_key" {
+  value     = data.azurerm_function_app_host_keys.api.default_function_key
+  sensitive = true
+}
+
+output "go_api_url" {
+  value = "https://${azurerm_linux_function_app.go_api.default_hostname}"
+}
+
+output "go_api_default_key" {
+  value     = data.azurerm_function_app_host_keys.go_api.default_function_key
+  sensitive = true
+}


### PR DESCRIPTION
### Summary
Migrate the frontend application to connect to the new Go Custom Handler API in the OpenTofu infrastructure configs. Refactor the infrastructure by consolidating both the legacy Node.js and the Go Function App resource definitions inside the `function_app` module, simplifying the root configuration.

### List of Changes
- Switch the App Service environment variables in `tofu/modules/app_service/main.tf` to point the frontend URL and access key to the Go API.
- Consolidate Go API service plans and Function App resources inside `tofu/modules/function_app/main.tf` and export their host keys and hostname endpoints as module outputs.

### Verification
- [x] Run `tofu validate` to verify syntax and structural correctness of the module refactoring.

