### PR TITLE
refactor(tofu): add moved blocks for Go API state migration

### DIFF
--- a/tofu/main.tf
+++ b/tofu/main.tf
@@ -113,3 +113,13 @@ output "go_api_default_key" {
   description = "The default host key of the Go Custom Handler Function App"
 }
 
+moved {
+  from = azurerm_service_plan.go_plan
+  to   = module.function_app.azurerm_service_plan.go_plan
+}
+
+moved {
+  from = azurerm_linux_function_app.go_api
+  to   = module.function_app.azurerm_linux_function_app.go_api
+}
+


### PR DESCRIPTION
### Summary
Add declarative state migration blocks to the OpenTofu configuration. This instructs OpenTofu to automatically rename the Go API service plan and function app resources in the remote state, resolving duplicate resource creation failures during deployment.

### List of Changes
- Append `moved` blocks for `azurerm_service_plan.go_plan` and `azurerm_linux_function_app.go_api` to `tofu/main.tf` to map their locations to the new `module.function_app` paths.

### Verification
- [x] Run `tofu validate` to verify syntax and structural correctness of the state migration configuration.

