### PR TITLE
refactor(workflow): fix Next.js copy paths and use webapps-deploy

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -5,12 +5,8 @@ on:
     branches: [main]
     paths:
       - 'tofu/**'
-      - 'api/**'
       - 'apiv2/**'
-      - 'shared/**'
       - 'frontend/**'
-      - 'package.json'
-      - 'package-lock.json'
   workflow_dispatch:
 
 permissions:
@@ -124,10 +120,9 @@ jobs:
 
       - name: Package Frontend
         run: |
-          # The standalone output includes everything needed to run
-          # We also need to include 'public' and 'static' for Next.js to serve them
-          cp -r frontend/public frontend/.next/standalone/frontend/
-          cp -r frontend/.next/static frontend/.next/standalone/frontend/.next/
+          # Copy public and static assets directly into the standalone directory structure
+          cp -r frontend/public frontend/.next/standalone/
+          cp -r frontend/.next/static frontend/.next/standalone/.next/
           
           # Zip the standalone folder
           cd frontend/.next/standalone
@@ -139,14 +134,8 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy Frontend to Azure Web App
-        run: |
-          az webapp deployment source config-zip \
-            --name ${{ env.FRONTEND_APP_NAME }} \
-            --resource-group ${{ env.RESOURCE_GROUP }} \
-            --src frontend-deploy.zip
-          
-          # Set the startup command for Next.js standalone
-          az webapp config set \
-            --name ${{ env.FRONTEND_APP_NAME }} \
-            --resource-group ${{ env.RESOURCE_GROUP }} \
-            --startup-file "node frontend/server.js"
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ env.FRONTEND_APP_NAME }}
+          package: frontend-deploy.zip
+          startup-command: "node frontend/server.js"


### PR DESCRIPTION
### Summary
Fix Next.js standalone static asset copy paths and transition the frontend deployment step to the official azure/webapps-deploy GitHub Action. This resolves deployment hangs caused by Azure CLI config-zip polling and ensures static files are served correctly.

### List of Changes
- Correct the static assets copying destinations inside the `Package Frontend` step to copy folders directly to the standalone directory root (`frontend/.next/standalone/`).
- Replace raw Azure CLI `az webapp` commands in the deployment step with the official `azure/webapps-deploy@v3` Action.
- Clean up trigger path filters in the deployment workflow to remove deleted Node workspaces.

### Verification
- [x] Manually ran the asset copying and zipping steps locally and verified that all public/static files are packaged at the correct standalone root paths.

