### PR TITLE
fix(workflow): correct Next.js standalone startup command

### DIFF
--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -138,4 +138,4 @@ jobs:
         with:
           app-name: ${{ env.FRONTEND_APP_NAME }}
           package: frontend-deploy.zip
-          startup-command: "node frontend/server.js"
+          startup-command: "node server.js"


### PR DESCRIPTION
### Summary
Correct the App Service startup command for the Next.js standalone server, resolving a 503 boot crash. Since the monorepo is flattened, the compiled server.js sits at the zip root instead of a nested subdirectory.

### List of Changes
- Modify the `startup-command` parameter in `.github/workflows/infra-deploy.yml` to execute `node server.js` from the unzipped root directory.
- Fix runtime boot failures where the App Service container was unable to locate `/home/site/wwwroot/frontend/server.js`.

### Verification
- [x] Downloaded and analyzed the App Service container failure logs (`failure.log`) to verify the exact Node.js startup path loading error.

