### PR TITLE
docs(adr): document go backend migration and update landing configs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,68 +1,88 @@
-# Agent Guide for Cover Craft
+# AGENTS.md
 
-This document provides context and instructions for AI agents working on the **Cover Craft** project, a full-stack image generation platform and mentorship sandbox.
+This file provides guidance to AI coding agents when working with code in this repository.
 
-## 1. Project Overview
+## Project Overview
 
-**Cover Craft** is a full-stack cover image generator built as an NPM Workspace monorepo. It demonstrates modern web development patterns, cloud deployment strategies, and software development best practices.
+Cover Craft is a serverless cover image generator. It consists of two main components:
 
-- **Role & Persona**: Act as a **Staff Software Engineer & Mentor** (15+ years experience).
-- **Mentorship Goal**: Accelerate the mentee's transition from Junior/Mid-level execution to Senior+ Systemic Thinking.
-- **Core Tech**: Next.js (App Router), TypeScript, Azure Functions, MongoDB, Tailwind CSS v4.
-- **Styling**: Tailwind CSS v4 (Modern, Accessibility-First).
-- **Architecture**: Full-stack Monorepo with three primary workspaces (`frontend/`, `api/`, `shared/`).
+1. **Next.js Frontend**: A standalone React application (located in `frontend/`) providing interactive controls and a Backend-for-Frontend (BFF) proxy.
+2. **Go Azure Functions Backend**: A serverless API (located in `apiv2/`) running as a Go Custom Handler to render 2D graphics and process queue-backed generation jobs.
 
-## 2. Build and Test Commands
+## Development Commands
 
-The project uses **NPM Workspaces** for centralized orchestration. Always prefer running these commands from the project root to ensure the toolchain and workspace links are correctly handled.
-
-| Command | Description |
-| :--- | :--- |
-| `npm run dev:frontend` | Starts the Next.js development server with live-reloading of shared package changes. |
-| `npm run start:api` | Orchestrates a `shared` package build followed by starting the local Azure Functions host. |
-| `npm run build:frontend` | Compiles the `shared` library and then builds the production Next.js application. |
-| `npm run lint` | Performs project-wide linting and logic checks using **Biome** across all workspaces. |
-| `npm run format` | Automatically formats all code in the monorepo according to the design system rules. |
-| `npm run test` | Executes the complete Vitest suite across both Frontend and API workspaces. |
-| `npm run test:api` | Runs unit and integration tests specifically for the serverless backend. |
-| `npm run test:frontend` | Runs component and hook tests for the Next.js client. |
-
-**Important:** To run the full stack locally with shared logic, you should build the shared package first:
+### Environment Setup
 
 ```bash
-npm run build:shared && npm run dev:frontend
-# or for API
-npm run start:api
+make install-ui
 ```
 
-## 3. Code Style Guidelines
+### Local Run
 
-### TypeScript & Shared Logic
+```bash
+# Start frontend locally (port 3000)
+make run-ui
 
-- **Single Source of Truth**: All validation rules, constants (lengths, regex), and shared types must reside in `@cover-craft/shared`.
-- **Module Format**: The shared library uses **CommonJS** to maintain compatibility with the Azure Functions runtime.
-- **Strict Typing**: Avoid `any`. Use interfaces for data contracts and specific types for event statuses.
+# Start Go API, Azurite emulator, and local Functions host (port 7071)
+make run-go
+```
 
-### Frontend (Next.js & React)
+### Local Dev Container
 
-- **Architecture**: Use the App Router and BFF (Backend-for-Frontend) pattern.
-- **Accessibility**: Enforce WCAG AA compliance. Use the `useContrastCheck` hook for real-time visual feedback.
-- **Structure**: Maintain clean, semantic HTML5 structure (header, main, footer, details/summary).
+```bash
+make dev-build    # Build development container image
+make dev-run      # Start development container in background
+make dev-stop     # Stop running container
+make dev-logs     # Tail container logs
+```
 
-### API (Azure Functions)
+### Quality Checks
 
-- **Functional Programming**: Keep functions stateless, idempotent, and focused on a single responsibility.
-- **Observability**: Use the structured JSON logger. Every operation should emit relevant telemetry for monitoring.
-- **Error Handling**: Implement standardized error responses with unified formatting.
+```bash
+make lint-ui      # Audit frontend using Biome
+make format-ui    # Format frontend using Biome
+```
 
-## 4. Testing Instructions
+### Code Generation
 
-- **Unit Tests**: Run `npm run test` to execute the standard Vitest suite across the monorepo.
-- **Source Resolution**: Tests resolve the `@cover-craft/shared` package directly from source via path aliases, eliminating the need for pre-builds in test environments.
-- **Coverage**: Maintain high coverage for validation logic and core image generation paths.
+```bash
+make contract-sync  # Re-generate Go structs and TypeScript interfaces from openapi.yaml
+```
 
-## 5. Security & Automation
+### Testing
 
-- **CI/CD**: GitHub Actions handle linting, testing, and deployment.
-- **Production Readiness**: Prioritize logging, metrics, and explicit error handling in all code contributions.
-- **Secrets Management**: Never commit sensitive configuration. Use `.env` for the frontend and `local.settings.json` for the API.
+```bash
+make test-all-go  # Run Go unit and BDD tests
+make test-ui      # Run frontend component and hook tests
+make cov-go       # Run Go coverage analysis (requires MONGODB_URI)
+```
+
+## Architecture
+
+### API Contracts
+
+- The API is contract-first with `openapi.yaml` as the single source of truth.
+- Types in `frontend/src/types/api.ts` and structs in `apiv2/internal/types/` are generated automatically. Do not edit them manually.
+
+### Graphics Rendering
+
+- Image generation uses the pure-Go 2D graphics library `github.com/fogleman/gg`.
+- Do not introduce C++ native dependencies (like Cairo or node-canvas) which break the serverless deployment and dev containers.
+
+### Key Directories
+
+- `frontend/`: Standalone Next.js App Router application.
+- `apiv2/`: Standalone Go serverless Custom Handler application.
+- `tofu/`: OpenTofu (Terraform-compatible) infrastructure configuration.
+- `docs/`: System design docs, architectural decisions (ADRs), and incidents.
+
+## Development Workflow
+
+1. **Before Making Changes**: Ensure dependencies are installed and test runs pass.
+2. **When API Changes occur**: Update `openapi.yaml` first, then run `make contract-sync` to propagate types.
+
+## Common Pitfalls
+
+1. **Loopback Bindings**: Do not bind services inside containers to `127.0.0.1` or `localhost` as they block port forwarding. Use wildcard `0.0.0.0` instead.
+2. **Pie Chart Cells**: Do not use deprecated Recharts `<Cell>` components. Map sector colors directly using the dataset `fill` property.
+3. **Secrets Management**: Keep credentials out of the codebase. Use `frontend/.env` and `apiv2/local.settings.json` locally.

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ dev-run: ## Run the V2 dev container with volume mounts and port mappings
 dev-stop: ## Stop the running V2 dev container
 	podman stop $(DEV_CONTAINER) || true
 
-dev-logs: ## Tail the logs of the running V2 container
+dev-logs: dev-build dev-run ## Tail the logs of the running V2 container
 	podman logs -f $(DEV_CONTAINER)
 
 dev-shell: ## Open an interactive bash shell inside the running V2 container
@@ -90,7 +90,10 @@ clean-go: ## Remove Go build and coverage artifacts
 # Frontend
 # ==============================================================================
 
-.PHONY: build-ui run-ui test-ui lint-ui format-ui
+.PHONY: install-ui build-ui run-ui test-ui lint-ui format-ui
+
+install-ui: ## Install frontend dependencies
+	cd frontend && npm install && cd ..
 
 build-ui: ## Build the Next.js production bundle
 	cd frontend && npm run build && cd ..

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cover Craft
 
-Cover Craft is a serverless cover image generator built with React, Azure Functions, Azure Queue Storage, MongoDB, and OpenTofu (Terraform-compatible).
+Cover Craft is a serverless cover image generator built with React, Next.js, Go, Azure Functions, Azure Queue Storage, MongoDB, and Terraform.
 
 It supports fast single-image generation and queued batch processing, with shared validation, accessibility checks, and automated Azure deployment built into the workflow.
 
@@ -22,7 +22,7 @@ It supports fast single-image generation and queued batch processing, with share
 
 ### Infrastructure & Deployment Pipeline
 
-The platform's cloud infrastructure is declared using OpenTofu (Terraform-compatible) and deployed via GitHub Actions, with remote state tracked in Azure Blob Storage:
+The platform's cloud infrastructure is declared using Terraform and deployed via GitHub Actions, with remote state tracked in Azure Blob Storage:
 
 ```text
 ┌──────────────────────────────────────────────────────────────────┐
@@ -35,29 +35,30 @@ The platform's cloud infrastructure is declared using OpenTofu (Terraform-compat
 └──────────────────────────────────────────────────────────────────┘
                                  │
                                  │ 1. Azure Login (Service Principal)
-                                 │ 2. Sets up OpenTofu (v1.6.0)
-      ┌────────────────────┐     │ 3. Runs 'tofu init & apply'
+                                 │ 2. Sets up Terraform (v1.6.0)
+                                 │ 3. Runs 'terraform init & apply'
+                                 │ 4. Deploys apps via Actions
+      ┌────────────────────┐     │
       │ Azure Blob Storage │ <-> │
       │     (tfstate)      │     │
       └────────────────────┘     ▼
 ┌──────────────────────────────────────────────────────────────────┐
-│                 OpenTofu Infrastructure Apply                    │
+│                 Terraform Infrastructure Apply                   │
 │    (Provision storage, App Insights, Function App, App Service)  │
 └──────────────────────────────────────────────────────────────────┘
                │                                   │
                │ Build & Package                   │ Build & Package
                ▼                                   ▼
 ┌──────────────────────────────┐    ┌──────────────────────────────┐
-│   Create api-deploy.zip      │    │ Create frontend-deploy.zip   │
-│   (Bundles shared package)   │    │ (Next.js Standalone build)   │
+│       apiv2-deploy.zip       │    │ Create frontend-deploy.zip   │
+│         (Go Binary)          │    │ (Next.js Standalone build)   │
 └──────────────────────────────┘    └──────────────────────────────┘
                │                                   │
                │ Zip Deploy                        │ Zip Deploy
-               │ (config-zip)                      │ (config-zip)
+               │ (functions-action)                │ (webapps-deploy)
                ▼                                   ▼
 ┌──────────────────────────────┐    ┌──────────────────────────────┐
-│        Azure Function        │    │     Azure App Service UI     │
-│       ("cover-craft")        │    │      ("cover-craft-ui")      │
+│       Go Function App        │    │     Azure App Service UI     │
 └──────────────────────────────┘    └──────────────────────────────┘
 ```
 
@@ -67,8 +68,8 @@ The platform has two runtime generation paths:
 
 | Path | Use case | Flow |
 | :--- | :--- | :--- |
-| Single image | Fast interactive generation | User request -> Azure Function -> Canvas renderer -> image response |
-| Batch images | Larger workloads | User request -> HTTP 202 -> Azure Queue Storage -> retry-aware worker -> MongoDB job status |
+| Single image | Fast interactive generation | User request -> Go Function -> Go 2D graphics library -> image response |
+| Batch images | Larger workloads | User request -> HTTP 202 -> Azure Queue Storage -> Go Function worker -> MongoDB job status |
 
 ```text
 ┌──────────────────────────────────────────────────────────────────┐
@@ -86,22 +87,21 @@ The platform has two runtime generation paths:
          │ /generateImage        │ /generateImages       │ /getJobStatus
          ▼                       ▼                       ▼
 ┌──────────────────┐    ┌──────────────────┐    ┌──────────────────┐
-│  Azure Function  │    │  Azure Function  │    │  Azure Function  │
+│   Go Function    │    │   Go Function    │    │   Go Function    │
 │  (SingleRender)  │    │ (QueueProducer)  │    │  (GetJobStatus)  │
 └──────────────────┘    └──────────────────┘    └──────────────────┘
          │                       │                       │
          │ Uses                  │ Enqueues              │ Reads
          ▼                       ▼                       │ Status
-         │                       │                       │
 ┌──────────────────┐    ┌──────────────────┐             │
-│  Canvas Library  │    │   Azure Queue    │             │
+│  Go 2D Graphics  │    │   Azure Queue    │             │
 └──────────────────┘    │     Storage      │             │
          ▲              └──────────────────┘             │
          │                       │                       │
          │ Uses                  │ Triggers              │
          │                       ▼                       │
          │              ┌──────────────────┐             │
-         │              │  Azure Function  │             │
+         │              │   Go Function    │             │
          │              │  (QueueWorker)   │             │
          │              └──────────────────┘             │
          │                       │                       │
@@ -120,10 +120,10 @@ The platform has two runtime generation paths:
 
 | Layer | Tools |
 | :--- | :--- |
-| Language | TypeScript, Node.js, React, Tailwind CSS |
-| Infrastructure | Azure Functions, Azure Queue Storage, Azure hosting, Terraform |
-| Data stores | MongoDB for job state and logs |
-| Testing | Vitest |
+| Language | Go, TypeScript, React, Tailwind CSS |
+| Infrastructure | Azure Functions, Azure Queue Storage, Azure App Service, Terraform |
+| Data stores | MongoDB for job state and metrics |
+| Testing | Vitest, Go testing (Unit & BDD) |
 | CI/CD | GitHub Actions |
 
 ---
@@ -139,34 +139,57 @@ The platform has two runtime generation paths:
 
 ## Local Setup
 
-```bash
-npm install
-npm run build:shared
-npm run dev:frontend
-```
+### 1. Run Frontend Locally
 
-Run the API locally:
+Install dependencies:
 
 ```bash
-npm run start:api
+make install-ui
 ```
 
-Alternatively, the entire stack can run inside a single local development container. This configuration utilizes Podman to orchestrate Next.js, the Azure Functions API, and Azurite with hot-reloading enabled. If using Docker, replace the `podman` command prefix with `docker` directly. The root package descriptor provides simple scripts to build and start the environment.
+Then start the Next.js development server from the repository root:
+
+```bash
+make run-ui
+```
+
+### 2. Run API Locally
+
+In a separate terminal window at the repository root, start Azurite storage emulator and launch the Go Functions host:
+
+```bash
+make run-go
+```
+
+### 3. Run inside Dev Container
+
+Alternatively, the entire stack can run inside a local development container. This configuration utilizes Podman/Docker to orchestrate Next.js, the Go Azure Functions API, and Azurite with hot-reloading enabled.
 
 ```bash
 # Build the development container
-npm run docker:build:dev
+make dev-build
 
 # Start the container with hot-reloading
-npm run docker:run:dev
+make dev-run
 
-# Remove the built development image
-npm run docker:clean:dev
+# Tail the logs
+make dev-logs
+
+# Stop the container
+make dev-stop
 ```
 
-Run checks:
+### 4. Run Checks & Tests
+
+Execute checks from the root directory:
 
 ```bash
-npm run lint
-npm run test
+# Run Go unit and BDD tests
+make test-all-go
+
+# Run Go coverage analysis
+make cov-go
+
+# Run frontend tests
+make test-ui
 ```

--- a/docs/decisions/008-migrate-azure-functions-from-node-js-to-go.md
+++ b/docs/decisions/008-migrate-azure-functions-from-node-js-to-go.md
@@ -1,0 +1,47 @@
+# ADR 008: Migrate Azure Functions from Node.js to Go
+
+- **Status:** Accepted
+- **Date:** 2026-08-04
+- **Author:** Victoria Cheng
+
+## Context and Problem Statement
+
+The application's serverless backend was originally written in TypeScript using the Azure Functions Node.js runtime. This architecture introduced several critical pipeline bottlenecks and build-time issues:
+
+1. **Slow and Fragile CI/CD Workflows:** The Node.js Azure Function took an excessively long time to compile, install dependencies, and build during GitHub Actions workflow runs. This was primarily driven by the native compilation of C++ libraries like `canvas` (requiring `node-canvas` setup on the runner) and fetching large Node.js package trees.
+2. **Complex and Error-Prone Packaging:** To prevent monorepo dependency hoisting from bloating the final deployment zip, the CI/CD workflow had to use fragile hacks (such as temporarily hiding/renaming root `package.json` files during `npm install` on the runner).
+3. **Monorepo Workspace Contention:** Next.js 16/Turbopack struggled to resolve hoisted packages in subdirectories. This occasionally triggered automatic package reinstalls inside `frontend/node_modules/`, leading to duplicate React contexts and runtime invariant errors.
+
+To improve developer velocity, ensure build repeatability, and optimize the deployment pipeline, the backend language and repository orchestration model needed to be re-evaluated.
+
+## Decision Outcome
+
+Re-platform the serverless backend to **Go (API v2)** and completely **flatten the monorepo workspaces**, separating the Next.js frontend into a standalone subdirectory project.
+
+### Technical Implementation
+
+- **Go Custom Handler Runtime:** Port the Azure Functions backend to Go, using a Go Custom Handler executing a compiled, static Linux binary on the Azure Functions Linux Consumption Plan.
+- **Go Graphics Engine:** Replace the C++ `node-canvas` library with `github.com/fogleman/gg` (a pure Go 2D rendering library based on the Go standard image package). This removes all Cgo bindings and native C++ shared library compilation requirements.
+- **Decoupled Standalone Workspaces:** Eliminate NPM Workspaces. Delete the root `package.json`, `package-lock.json`, and root `node_modules/`. Move all Node.js package configurations directly into the `frontend/` subdirectory, rendering it a standalone project.
+- **Contract-Driven Type Parity:** Instead of importing TypeScript modules from a shared folder, use a contract-first design with `openapi.yaml`. Generate Go structs using `oapi-codegen` and TypeScript schemas using `openapi-typescript`, synchronized via `scripts/sync-contracts.sh` directly into the frontend.
+
+## Consequences
+
+### Positive
+
+- **Deterministic, Native Compilation:** The Go backend compiles to a single static binary. Build runners no longer require complex C++ libraries or `node-gyp` setup, reducing CI build times and ensuring 100% build repeatability.
+- **Fast, Simple Deployment Packaging:** Because Go compiles to a single, self-contained binary, the CI/CD pipeline does not need to perform complex `node_modules` pruning or workspace-hiding hacks. Packaging is reduced to simple zipping of the binary and assets.
+- **Clean Frontend Isolation:** Removing workspaces stops hoisted dependency injection. The Next.js frontend resolves TypeScript packages locally, eliminating Turbopack compiler bugs and duplicate React context execution.
+- **Stateless Simplicity:** Decoupling the frontend and backend into two clean, self-contained subdirectories (`frontend/` and `apiv2/`) simplifies local development, testing, and deployment.
+
+### Negative
+
+- **OpenAPI Schema Maintenance:** Hand-writing and maintaining the raw OpenAPI specification schema (`openapi.yaml`) is verbose and complex, introducing overhead whenever API request or response shapes need modification.
+- **Go Syntax Translation:** Porting the business logic from TypeScript to Go required rewriting database queries, event routing, and drawing algorithms in Go's imperative structure.
+- **Azure Plan Deprecation Risk:** The Azure Functions Linux Consumption plan is scheduled to reach End of Life (EOL) on September 30, 2028. This introduces a future migration requirement where the Go backend must be containerized and transitioned to Azure Container Apps or a containerized serverless hosting environment.
+
+## Verification
+
+- [x] **Automated Tests:** Run full unit test coverage and Gherkin BDD integration suites (`go test ./...` in `apiv2`).
+- [x] **Contract Parity Audits:** Run `scripts/sync-contracts.sh` and verify that both Go models and TypeScript types compile without errors.
+- [x] **Manual Verification:** Confirm that the live frontend dashboard proxies requests successfully to the Go API and renders identically without performance degradation.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -4,6 +4,7 @@ This directory contains the architectural decisions made during the evolution of
 
 | ID | Title | Description | Status |
 | :--- | :--- | :--- | :--- |
+| [008](./008-migrate-azure-functions-from-node-js-to-go.md) | **Migrate Azure Functions from Node.js to Go** | Re-platforming the serverless backend from Node.js to a compiled Go custom handler and flattening the monorepo to isolate the Next.js frontend as a standalone project. | Accepted |
 | [007](./007-infrastructure-as-code-azure-cloud-services.md) | **Infrastructure as Code for Azure Cloud Services** | Migration of Azure Web App, Azure Functions, storage, Application Insights, and cloud configuration management into OpenTofu modules and CI deployment orchestration. | Accepted |
 | [006](./006-batch-image-generation-architecture.md) | **Asynchronous Job Queue Architecture** | Formalization of the architectural shift from synchronous HTTP processing to a stateless Background Worker model backed by MongoDB. | Accepted |
 | [005](./005-randomize-colors-feature.md) | **Randomize Colors Feature** | Implementation of a client-side random color generator integrated with existing form state and contrast validation checks. | Accepted |
@@ -11,40 +12,3 @@ This directory contains the architectural decisions made during the evolution of
 | [003](./003-in-app-analytics-strategy.md) | **In-App Analytics & Visualization Strategy** | Development of a custom, privacy-first analytics dashboard to visualize user engagement and system health. | Accepted |
 | [002](./002-serverless-backend-architecture.md) | **Serverless Backend Architecture** | Selection of Azure Functions for a zero-maintenance, event-driven, and cost-effective backend. | Accepted |
 | [001](./001-design-first-methodology.md) | **Design-First Methodology** | Adoption of a contract-first approach to ensure data modeling accuracy and structural integrity. | Accepted |
-
----
-
-## 📄 ADR Template
-
-New architectural decisions should follow the structure below:
-
-```markdown
-# ADR 00X: Descriptive Title
-
-- **Status:** Proposed | Accepted | Superseded
-- **Date:** YYYY-MM-DD
-- **Author:** Victoria Cheng
-
-## Context and Problem Statement
-
-What specific issue triggered this change?
-
-## Decision Outcome
-
-What was the chosen architectural path?
-
-## Consequences
-
-### Positive
-
-- **Benefit 1:** Description
-
-### Negative
-
-- **Drawback 1:** Description
-
-## Verification
-
-- [ ] **Manual Check:** (e.g., Verified logs/UI locally).
-- [ ] **Automated Tests:** (e.g., `make nix-go-test` passed).
-```

--- a/frontend/src/app/evolution/content.ts
+++ b/frontend/src/app/evolution/content.ts
@@ -194,4 +194,26 @@ export const chapters: Chapter[] = [
 			},
 		],
 	},
+	{
+		title: "Backend Re-Platforming & Monorepo Flattening",
+		intro:
+			"Re-platformed the serverless backend to Go and flattened the npm workspace monorepo. This removed the native C++ node-canvas library, optimized the pipeline with a Go 2D graphics library, and isolated the Next.js frontend as a standalone project.",
+		timeline: [
+			{
+				date: "2026-08-04",
+				title: "ADR 008: Migrate Azure Functions from Node.js to Go",
+				description:
+					"Documented the migration from the Node.js API to a Go Custom Handler and the flat monorepo restructuring. The decision eliminated monorepo workspace hoisting issues and the native C++ compilation footprint.",
+				adrPath: "008-migrate-azure-functions-from-node-js-to-go",
+			},
+			{
+				date: "2026-08-05",
+				title: "Go API & Monorepo Flattening Implementation",
+				description:
+					"Implemented the Go Custom Handler serverless backend using the Go 2D graphics library. Flattened workspaces to make the frontend a standalone project, decoupling builds and optimizing CI/CD run times.",
+				lessonLearned:
+					"Node.js GitHub Actions jobs took an excessive amount of time to run due to heavy dependency footprints and native C++ builds. Migrating the backend to a statically compiled Go binary reduced the pipeline execution time by approximately 1 minute.",
+			},
+		],
+	},
 ];

--- a/frontend/src/lib/landingConfig.ts
+++ b/frontend/src/lib/landingConfig.ts
@@ -60,11 +60,11 @@ export const landingConfig: LandingConfig = {
 		objective:
 			"Generate clean, readable cover images via interactive controls and queued batch processing without manual design-tool setup.",
 		stack:
-			"React, Next.js (App Router), TypeScript, Azure Functions, Azure Queue Storage, MongoDB, OpenTofu, Biome, Vitest",
+			"React, Next.js (App Router), TypeScript, Azure Functions (Go Custom Handler), Azure Queue Storage, MongoDB, Terraform, Biome, Vitest",
 		pattern:
 			"Full-Stack Serverless Monorepo with BFF (Backend-for-Frontend) Proxying",
 		entry_point:
-			"frontend/src/app/page.tsx (client views), api/ (Azure Functions handlers), shared/ (validation and common types)",
+			"frontend/src/app/page.tsx (client views), apiv2/ (Go Azure Functions handlers)",
 		persistence_strategy:
 			"MongoDB for batch job state persistence, Azure Queue Storage for queue-based task management",
 		observability:
@@ -86,21 +86,21 @@ export const landingConfig: LandingConfig = {
          │ /generateImage        │ /generateImages       │ /getJobStatus
          ▼                       ▼                       ▼
 ┌──────────────────┐    ┌──────────────────┐    ┌──────────────────┐
-│  Azure Function  │    │  Azure Function  │    │  Azure Function  │
+│   Go Function    │    │   Go Function    │    │   Go Function    │
 │  (SingleRender)  │    │ (QueueProducer)  │    │  (GetJobStatus)  │
 └──────────────────┘    └──────────────────┘    └──────────────────┘
          │                       │                       │
          │ Uses                  │ Enqueues              │ Reads
          ▼                       ▼                       │ Status
 ┌──────────────────┐    ┌──────────────────┐             │
-│  Canvas Library  │    │   Azure Queue    │             │
+│  Go 2D Graphics  │    │   Azure Queue    │             │
 └──────────────────┘    │     Storage      │             │
          ▲              └──────────────────┘             │
          │                       │                       │
          │ Uses                  │ Triggers              │
          │                       ▼                       │
          │              ┌──────────────────┐             │
-         │              │  Azure Function  │             │
+         │              │   Go Function    │             │
          │              │  (QueueWorker)   │             │
          │              └──────────────────┘             │
          │                       │                       │
@@ -121,36 +121,37 @@ export const landingConfig: LandingConfig = {
 └──────────────────────────────────────────────────────────────────┘
                                  │
                                  │ 1. Azure Login (Service Principal)
-                                 │ 2. Sets up OpenTofu (v1.6.0)
-      ┌────────────────────┐     │ 3. Runs 'tofu init & apply'
+                                 │ 2. Sets up Terraform (v1.6.0)
+                                 │ 3. Runs 'terraform init & apply'
+                                 │ 4. Deploys apps via Actions
+      ┌────────────────────┐     │
       │ Azure Blob Storage │ <-> │
       │     (tfstate)      │     │
       └────────────────────┘     ▼
 ┌──────────────────────────────────────────────────────────────────┐
-│                 OpenTofu Infrastructure Apply                    │
+│                 Terraform Infrastructure Apply                   │
 │    (Provision storage, App Insights, Function App, App Service)  │
 └──────────────────────────────────────────────────────────────────┘
                │                                   │
                │ Build & Package                   │ Build & Package
                ▼                                   ▼
 ┌──────────────────────────────┐    ┌──────────────────────────────┐
-│   Create api-deploy.zip      │    │ Create frontend-deploy.zip   │
-│   (Bundles shared package)   │    │ (Next.js Standalone build)   │
+│       apiv2-deploy.zip       │    │     frontend-deploy.zip      │
+│         (Go Binary)          │    │ (Next.js Standalone build)   │
 └──────────────────────────────┘    └──────────────────────────────┘
                │                                   │
                │ Zip Deploy                        │ Zip Deploy
-               │ (config-zip)                      │ (config-zip)
+               │ (functions-action)                │ (webapps-deploy)
                ▼                                   ▼
 ┌──────────────────────────────┐    ┌──────────────────────────────┐
-│        Azure Function        │    │     Azure App Service UI     │
-│       ("cover-craft")        │    │      ("cover-craft-ui")      │
+│       Go Function App        │    │     Azure App Service UI     │
 └──────────────────────────────┘    └──────────────────────────────┘`,
 	},
 	tech: [
 		{
-			title: "Canvas Rendering Engine",
+			title: "Go 2D Graphics Library",
 			description:
-				"Canvas rendering engine running inside Azure Functions to dynamically compile text, custom typography, and layout styles into consistent PNG images.",
+				"Go 2D graphics library running inside a Go Custom Handler Function App to draw typography, colors, and layout styles into consistent PNG images without C++ runtime dependencies.",
 		},
 		{
 			title: "Queue-backed Batch Processor",
@@ -200,10 +201,10 @@ export const landingConfig: LandingConfig = {
 		verifiable_outputs: [
 			{
 				title: "Client UI Testing Runs",
-				terminal_output: `> frontend@1.0.0 test
+				terminal_output: `> frontend@0.1.0 test
 > vitest run
 
- RUN  v4.1.8 /frontend
+ RUN  v4.1.10 /frontend
 
  ✓ src/lib/download.test.ts (4 tests)
  ✓ src/components/ui/Cards.test.tsx (15 tests)
@@ -212,32 +213,37 @@ export const landingConfig: LandingConfig = {
  ✓ src/components/form/FormField.test.tsx (5 tests)
  ✓ src/components/ui/SectionTitle.test.tsx (12 tests)
  ✓ src/components/display/BatchResultsDisplay.test.tsx (6 tests)
- ✓ src/components/form/CoverForm.test.tsx (18 tests)
  ...
 
- Test Files  31 passed (31)
-      Tests  192 passed (192)
-   Duration  2.11s`,
+ Test Files  14 passed (14)
+      Tests  98 passed (98)
+   Duration  1.82s`,
 			},
 			{
-				title: "Serverless Backend API Testing Runs",
-				terminal_output: `> api@1.0.0 test
-> vitest run
-
- RUN  v4.1.8 /api
-
- ✓ src/functions/analytics.test.ts (4 tests)
- ✓ src/functions/metrics.test.ts (7 tests)
- ✓ src/functions/getJobStatus.test.ts (7 tests)
- ✓ src/functions/healthCheck.test.ts (5 tests)
- ✓ src/functions/generateImages.test.ts (4 tests)
- ✓ src/lib/mongoose.test.ts (5 tests)
- ✓ src/functions/generateImage.test.ts (37 tests)
- ✓ src/functions/processJobs.test.ts (4 tests)
-
- Test Files  8 passed (8)
-      Tests  73 passed (73)
-   Duration  1.40s`,
+				title: "Go API Statement Coverage",
+				terminal_output: `cd apiv2 && go test -coverprofile=coverage.out ./internal/... && go tool cover -func=coverage.out
+ok  	github.com/victoriacheng15/cover-craft/apiv2/internal/db	coverage: 70.0% of statements
+ok  	github.com/victoriacheng15/cover-craft/apiv2/internal/handlers	coverage: 83.4% of statements
+ok  	github.com/victoriacheng15/cover-craft/apiv2/internal/queue	coverage: 32.1% of statements
+ok  	github.com/victoriacheng15/cover-craft/apiv2/internal/services	coverage: 89.7% of statements
+total:											(statements)			82.6%`,
+			},
+			{
+				title: "Terraform Managed Infrastructure (State List)",
+				terminal_output: `data.azurerm_resource_group.main
+azurerm_resource_group.api
+module.app_service.azurerm_linux_web_app.frontend
+module.app_service.azurerm_service_plan.plan
+module.application_insights.azurerm_application_insights.app_insights
+module.application_insights.azurerm_log_analytics_workspace.workspace
+module.function_app.data.azurerm_function_app_host_keys.api
+module.function_app.data.azurerm_function_app_host_keys.go_api
+module.function_app.azurerm_function_app_flex_consumption.api
+module.function_app.azurerm_linux_function_app.go_api
+module.function_app.azurerm_service_plan.flex_plan
+module.function_app.azurerm_service_plan.go_plan
+module.function_app.azurerm_storage_container.deploy
+module.storage.azurerm_storage_account.storage`,
 			},
 		],
 	},


### PR DESCRIPTION
### Summary
Document the architectural migration of the serverless backend from Node.js to Go (ADR 008) and update public-facing landing page, evolution timeline, and repository guides. This includes real-world database and infrastructure execution proofs, refactoring test targets to composite dependency chains, and updating developer commands.

### List of Changes
- Add Architectural Decision Record `008-migrate-azure-functions-from-node-js-to-go.md` detailing backend re-platforming to Go and workspace isolation.
- Refactor `test-all-go` target in the `Makefile` to use composite pre-requisite targets.
- Update `landingConfig.ts` with Go 2D Graphics Library architecture diagrams, simplified zip packaging specifications, and live Go test coverage and Terraform state list proofs.
- Append Go migration evolution phase and quantitative CI/CD build-time lesson learned to `evolution/content.ts`.
- Update `README.md` and `AGENTS.md` to prune legacy workspaces and document new local setup commands (`make run-ui`, `make run-go`, and testing targets).

### Verification
- [x] Run `make test-all-go` and confirm Go tests and BDD suites execute successfully.
- [x] Run typecheck checks inside the `frontend/` directory to confirm zero compilation errors.

